### PR TITLE
fix: add client-side auth redirect for magic link flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
 import { EmailLogin } from '@/components/auth/email-login'
+import { AuthRedirect } from '@/components/auth/auth-redirect'
 
 export default function Home() {
   return (
     <div className="min-h-screen flex items-center justify-center p-8">
+      <AuthRedirect />
       <div className="max-w-2xl w-full text-center space-y-8">
         <div className="space-y-4">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">

--- a/components/auth/auth-redirect.tsx
+++ b/components/auth/auth-redirect.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+
+export function AuthRedirect() {
+  const router = useRouter()
+  
+  useEffect(() => {
+    const checkAndRedirect = async () => {
+      const supabase = createClient()
+      const { data: { session } } = await supabase.auth.getSession()
+      
+      if (session?.user) {
+        // User is authenticated, check their profile and workspace status
+        const [profileResult, workspaceResult] = await Promise.all([
+          supabase.from('users').select('id').eq('id', session.user.id).single(),
+          supabase.from('workspaces').select('slug').eq('owner_id', session.user.id).single()
+        ])
+        
+        if (!profileResult.data) {
+          router.push('/CreateUser')
+        } else if (!workspaceResult.data) {
+          router.push('/CreateWorkspace')
+        } else if (workspaceResult.data.slug) {
+          router.push(`/${workspaceResult.data.slug}`)
+        }
+      }
+    }
+    
+    // Check immediately
+    checkAndRedirect()
+    
+    // Also listen for auth state changes (when magic link is processed)
+    const supabase = createClient()
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        checkAndRedirect()
+      }
+    })
+    
+    return () => subscription.unsubscribe()
+  }, [router])
+  
+  return null
+}


### PR DESCRIPTION
## Problem
After clicking the magic link, users were redirected to the home page but stayed there until they manually refreshed. The middleware-only solution wasn't sufficient because:

1. When the magic link redirects back with the auth code, the user isn't authenticated yet at the middleware level
2. Authentication happens client-side after the page loads
3. By then, the user is already on the home page with no automatic redirect

## Solution
Added a client-side `AuthRedirect` component that:
- Checks authentication status immediately on page load
- Listens for `SIGNED_IN` events from Supabase auth
- Automatically redirects users based on their profile/workspace status
- Works seamlessly with the magic link flow without requiring a page refresh

## How it works
1. User clicks magic link
2. Redirected to home page with auth code
3. Supabase client processes the auth code
4. `AuthRedirect` component detects the `SIGNED_IN` event
5. Immediately redirects to appropriate destination:
   - No profile → `/CreateUser`
   - No workspace → `/CreateWorkspace`
   - Has both → `/{workspace-slug}`

## Testing
Deploy this and test the magic link flow - users should be automatically redirected without needing to refresh the page.

🤖 Generated with [Claude Code](https://claude.ai/code)