### PR TITLE
fix: handle auth callback redirect from home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,16 @@
 import { EmailLogin } from '@/components/auth/email-login'
+import { redirect } from 'next/navigation'
 
-export default function Home() {
+export default async function Home(props: {
+  searchParams: Promise<{ code?: string }>
+}) {
+  const searchParams = await props.searchParams
+  
+  // If there's an auth code in the URL, redirect to the callback route
+  if (searchParams.code) {
+    redirect(`/auth/callback?code=${searchParams.code}`)
+  }
+  
   return (
     <div className="min-h-screen flex items-center justify-center p-8">
       <div className="max-w-2xl w-full text-center space-y-8">


### PR DESCRIPTION
## Problem
When clicking the magic link email, users were being redirected to the home page (`/`) with the auth code parameter instead of `/auth/callback`. This meant the authentication wasn't being processed.

## Root Cause
Supabase appears to be redirecting to the base URL with the auth code as a query parameter, rather than to the specific callback route we specified.

## Solution
Added logic to the home page to check for an auth code parameter and redirect to `/auth/callback` if present. This ensures the authentication flow works regardless of where Supabase sends the user.

## Implementation
- Modified home page to accept and check for `code` search parameter
- If code is present, immediately redirect to `/auth/callback?code={code}`
- Used Next.js 15's async params pattern for proper handling

## Testing
After deploying this fix:
1. Click magic link in email
2. Should be redirected to `/auth/callback` (even if initially sent to `/`)
3. Authentication processes and redirects to `/workspace`
4. Finally redirected to appropriate destination

🤖 Generated with [Claude Code](https://claude.ai/code)