### PR TITLE
Fix header shifting when filter dropdowns open

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -120,6 +120,12 @@
   body {
     @apply bg-background text-foreground;
   }
+  
+  /* Prevent layout shift when scrollbar appears/disappears */
+  html {
+    overflow-y: scroll;
+    scrollbar-gutter: stable;
+  }
 }
 
 /* Custom scrollbar styles */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
       >
         {children}
       </body>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -70,7 +70,7 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
   return (
     <header className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50">
       <div className="w-full px-4 md:px-6 lg:px-8">
-        <div className="flex items-center h-16">
+        <div className="flex items-center h-16 relative isolate">
           {/* Left Section - Logo */}
           <div className="flex items-center flex-1">
             {onMenuToggle && (
@@ -92,7 +92,7 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
           </div>
           
           {/* Center Section - Search Bar */}
-          <div className="flex-1 flex justify-center px-4">
+          <div className="flex-1 flex justify-center px-4 min-w-0">
             <div className="w-full max-w-[600px] hidden md:block">
               <div className="relative">
                 <input

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -120,13 +120,13 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
     <>
       {/* Filters - Only show for issues list view */}
       {currentView === 'list' && (
-        <div className="border-b border-gray-200 bg-white">
-          <div className="px-6 py-4 flex items-center space-x-3">
-            <span className="text-sm text-gray-500">Filter by:</span>
+        <div className="border-b border-gray-200 bg-white overflow-hidden relative">
+          <div className="px-3 sm:px-6 py-3 sm:py-4 flex flex-wrap items-center gap-2 sm:gap-3 relative z-0">
+            <span className="text-sm text-gray-500 flex-shrink-0">Filter by:</span>
             
             {/* Status Filter */}
             <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-[180px] h-8 text-sm">
+              <SelectTrigger className="w-full sm:w-[180px] h-8 text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -140,7 +140,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
             
             {/* Priority Filter */}
             <Select value={priorityFilter} onValueChange={setPriorityFilter}>
-              <SelectTrigger className="w-[140px] h-8 text-sm">
+              <SelectTrigger className="w-full sm:w-[140px] h-8 text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -154,7 +154,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
             
             {/* Type Filter */}
             <Select value={typeFilter} onValueChange={setTypeFilter}>
-              <SelectTrigger className="w-[140px] h-8 text-sm">
+              <SelectTrigger className="w-full sm:w-[140px] h-8 text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary
- Fixed header layout shifting issue that occurred when selecting filter dropdowns
- The search box and user icon no longer shift to the right when filters are selected

## Changes
- Added `min-w-0` to header search section to prevent flex overflow
- Added `isolate` class to create new stacking context for header
- Added `scrollbar-gutter: stable` to HTML element to prevent layout shifts from scrollbar appearance/disappearance
- Added `overflow-x-hidden` to body to prevent horizontal scrolling
- Added proper containment to filter section with relative positioning

## Test plan
- [x] Open the issues list page
- [x] Click on any filter dropdown (Status, Priority, or Type)
- [x] Verify that the header elements (search box and user icon) do not shift position
- [x] Test selecting different filter options
- [x] Test on different screen sizes (mobile, tablet, desktop)

🤖 Generated with [Claude Code](https://claude.ai/code)