### PR TITLE
fix: Allow Ctrl+C/Cmd+C for system copy functionality

### DIFF
--- a/hooks/use-global-shortcuts.tsx
+++ b/hooks/use-global-shortcuts.tsx
@@ -99,17 +99,19 @@ export function useGlobalShortcuts({ workspaceSlug, onCreateIssue, onShowHelp, o
         return
       }
 
-      // Single key shortcuts
-      switch (key) {
-        case "c":
-          e.preventDefault()
-          onCreateIssue?.()
-          break
-        case "f":
-          e.preventDefault()
-          // TODO: Implement filter
-          console.log("Filter shortcut pressed")
-          break
+      // Single key shortcuts (only if no modifier keys are pressed)
+      if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+        switch (key) {
+          case "c":
+            e.preventDefault()
+            onCreateIssue?.()
+            break
+          case "f":
+            e.preventDefault()
+            // TODO: Implement filter
+            console.log("Filter shortcut pressed")
+            break
+        }
       }
     }
 


### PR DESCRIPTION
- Modify keyboard shortcut handler to only trigger 'c' key for issue creation when no modifier keys are pressed
- Ctrl+C and Cmd+C are now available for system copy operations
- Plain 'c' key still opens the create issue modal
- Added modifier key checks to prevent interference with system shortcuts

🤖 Generated with [Claude Code](https://claude.ai/code)