### PR TITLE
fix: Update command palette tests for Next Issue feature support

### DIFF
--- a/test/__tests__/user-experience/command-palette.test.tsx
+++ b/test/__tests__/user-experience/command-palette.test.tsx
@@ -13,11 +13,13 @@ vi.mock('next/navigation', () => ({
 // Helper component to test hook
 function CommandPaletteTestWrapper({ 
   workspaceSlug = 'test-workspace',
+  workspaceId = 'test-workspace-id',
   onCreateIssue = vi.fn(),
   onToggleViewMode = vi.fn(),
   onToggleSearch = vi.fn(),
 }: {
   workspaceSlug?: string
+  workspaceId?: string
   onCreateIssue?: () => void
   onToggleViewMode?: () => void
   onToggleSearch?: () => void
@@ -26,6 +28,7 @@ function CommandPaletteTestWrapper({
     <CommandPaletteProvider>
       <CommandPalette 
         workspaceSlug={workspaceSlug}
+        workspaceId={workspaceId}
         onCreateIssue={onCreateIssue}
         onToggleViewMode={onToggleViewMode}
         onToggleSearch={onToggleSearch}


### PR DESCRIPTION
## Summary
- Added `workspaceId` prop to command palette test wrapper
- Ensures tests accurately reflect the component's actual usage with the Next Issue AI recommendation feature

## Context
The Next Issue AI recommendation feature (already restored in PR #34) requires `workspaceId` to function properly. This PR updates the command palette tests to include this required prop.

## Test plan
- [ ] Verify command palette tests pass with the new prop
- [ ] Confirm Next Issue feature continues to work via Cmd+N shortcut
- [ ] Check that command palette opens and displays the Next Issue command

🤖 Generated with [Claude Code](https://claude.ai/code)