### PR TITLE
Fix Kanban board and workspace content to show all issues by default

### DIFF
--- a/components/issues/kanban-board.tsx
+++ b/components/issues/kanban-board.tsx
@@ -63,7 +63,7 @@ const priorityColors = {
 export function KanbanBoard({ 
   workspaceId, 
   onIssueClick,
-  statusFilter = 'exclude_done',
+  statusFilter = 'all',
   priorityFilter = 'all',
   typeFilter = 'all'
 }: KanbanBoardProps) {

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -109,8 +109,8 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   const [refreshKey, setRefreshKey] = useState(0)
   const [issuesViewMode, setIssuesViewMode] = useState<'list' | 'kanban'>('list')
   
-  // Filter states - default excludes done status
-  const [statusFilter, setStatusFilter] = useState<string>('exclude_done')
+  // Filter states - default shows all issues
+  const [statusFilter, setStatusFilter] = useState<string>('all')
   const [priorityFilter, setPriorityFilter] = useState<string>('all')
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [searchQuery, setSearchQuery] = useState<string>('')


### PR DESCRIPTION
## Summary
- Changed default status filter in KanbanBoard component to show all issues instead of excluding done issues
- Updated WorkspaceContent component to default to showing all issues in status filter

## Changes

### KanbanBoard Component
- Modified `statusFilter` default value from `'exclude_done'` to `'all'` to ensure done issues are visible by default

### WorkspaceContent Component
- Updated `statusFilter` state default from `'exclude_done'` to `'all'` to align with KanbanBoard and show all issues initially

## Test plan
- Verify Kanban board displays all issues including done status by default
- Confirm workspace content issues view defaults to showing all issues
- Check filtering behavior remains consistent when changing status filters manually

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/71b3912e-976c-4d8c-a603-67278d138b1e