### PR TITLE
feat: Dynamic filter updates when switching between List and Kanban views

### DIFF
--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -109,8 +109,9 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   const [refreshKey, setRefreshKey] = useState(0)
   const [issuesViewMode, setIssuesViewMode] = useState<'list' | 'kanban'>('list')
   
-  // Filter states - default shows all issues
-  const [statusFilter, setStatusFilter] = useState<string>('all')
+  // Filter states - default based on view mode
+  // List view defaults to Active (exclude_done), Kanban defaults to All
+  const [statusFilter, setStatusFilter] = useState<string>('exclude_done')
   const [priorityFilter, setPriorityFilter] = useState<string>('all')
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -184,7 +185,24 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
 
   // Handler to toggle between list and kanban views
   const handleToggleViewMode = () => {
-    setIssuesViewMode(prev => prev === 'list' ? 'kanban' : 'list')
+    setIssuesViewMode(prev => {
+      const newMode = prev === 'list' ? 'kanban' : 'list'
+      
+      // Update filters based on view mode
+      if (newMode === 'list') {
+        // List view default: Active issues (exclude done)
+        setStatusFilter('exclude_done')
+      } else {
+        // Kanban view default: All issues
+        setStatusFilter('all')
+      }
+      
+      // Reset other filters to default
+      setPriorityFilter('all')
+      setTypeFilter('all')
+      
+      return newMode
+    })
   }
 
   // Expose method to parent component
@@ -299,14 +317,30 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
               {/* View Mode Toggle */}
               <div className="flex items-center gap-1 border rounded-md p-1">
                 <button
-                  onClick={() => setIssuesViewMode('list')}
+                  onClick={() => {
+                    if (issuesViewMode !== 'list') {
+                      setIssuesViewMode('list')
+                      // List view default: Active issues (exclude done)
+                      setStatusFilter('exclude_done')
+                      setPriorityFilter('all')
+                      setTypeFilter('all')
+                    }
+                  }}
                   className={`p-1 rounded ${issuesViewMode === 'list' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
                   title="List view"
                 >
                   <List className="h-4 w-4" />
                 </button>
                 <button
-                  onClick={() => setIssuesViewMode('kanban')}
+                  onClick={() => {
+                    if (issuesViewMode !== 'kanban') {
+                      setIssuesViewMode('kanban')
+                      // Kanban view default: All issues
+                      setStatusFilter('all')
+                      setPriorityFilter('all')
+                      setTypeFilter('all')
+                    }
+                  }}
                   className={`p-1 rounded ${issuesViewMode === 'kanban' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
                   title="Kanban view"
                 >

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -183,24 +183,25 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
     window.history.pushState({}, '', `/${workspace.slug}/cookbook`)
   }
 
+  // Shared function to update filters based on view mode
+  const updateFiltersForViewMode = (viewMode: 'list' | 'kanban') => {
+    if (viewMode === 'list') {
+      // List view default: Active issues (exclude done)
+      setStatusFilter('exclude_done')
+    } else {
+      // Kanban view default: All issues
+      setStatusFilter('all')
+    }
+    // Reset other filters to default
+    setPriorityFilter('all')
+    setTypeFilter('all')
+  }
+
   // Handler to toggle between list and kanban views
   const handleToggleViewMode = () => {
     setIssuesViewMode(prev => {
       const newMode = prev === 'list' ? 'kanban' : 'list'
-      
-      // Update filters based on view mode
-      if (newMode === 'list') {
-        // List view default: Active issues (exclude done)
-        setStatusFilter('exclude_done')
-      } else {
-        // Kanban view default: All issues
-        setStatusFilter('all')
-      }
-      
-      // Reset other filters to default
-      setPriorityFilter('all')
-      setTypeFilter('all')
-      
+      updateFiltersForViewMode(newMode)
       return newMode
     })
   }
@@ -320,10 +321,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
                   onClick={() => {
                     if (issuesViewMode !== 'list') {
                       setIssuesViewMode('list')
-                      // List view default: Active issues (exclude done)
-                      setStatusFilter('exclude_done')
-                      setPriorityFilter('all')
-                      setTypeFilter('all')
+                      updateFiltersForViewMode('list')
                     }
                   }}
                   className={`p-1 rounded ${issuesViewMode === 'list' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
@@ -335,10 +333,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
                   onClick={() => {
                     if (issuesViewMode !== 'kanban') {
                       setIssuesViewMode('kanban')
-                      // Kanban view default: All issues
-                      setStatusFilter('all')
-                      setPriorityFilter('all')
-                      setTypeFilter('all')
+                      updateFiltersForViewMode('kanban')
                     }
                   }}
                   className={`p-1 rounded ${issuesViewMode === 'kanban' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}


### PR DESCRIPTION
## Summary
- Implemented dynamic filter updates based on view type selection without page refresh
- List view now defaults to showing Active issues (exclude_done)
- Kanban view defaults to showing All issues
- Users can still manually change filters after switching views

## Test plan
- [x] Switch from List to Kanban view - verify filters update to "All"
- [x] Switch from Kanban to List view - verify filters update to "Active"
- [x] Manually change filters in List view, then switch to Kanban - verify filters reset to Kanban defaults
- [x] Manually change filters in Kanban view, then switch to List - verify filters reset to List defaults
- [x] Verify no page refresh occurs during view switching
- [x] Run test suite - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)