### PR TITLE
Fix Settings page CommandPaletteProvider error

### DIFF
--- a/app/[slug]/settings/page.tsx
+++ b/app/[slug]/settings/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import { WorkspaceWithMobileNav } from '@/components/layout/workspace-with-mobile-nav'
-import { ApiSettings } from '@/components/settings/api-settings'
+import { SettingsPageContent } from './settings-page-content'
 
 interface SettingsPageProps {
   params: Promise<{ slug: string }>
@@ -37,22 +36,13 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
   }
   
   return (
-    <WorkspaceWithMobileNav workspace={workspace}>
-      <div className="max-w-4xl mx-auto p-6">
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold mb-2">Workspace Settings</h1>
-          <p className="text-gray-600">Manage your workspace configuration and integrations</p>
-        </div>
-        
-        <ApiSettings 
-          workspaceId={workspace.id}
-          initialSettings={{
-            api_key: workspaceData.api_key,
-            api_provider: workspaceData.api_provider,
-            agents_content: workspaceData.agents_content
-          }}
-        />
-      </div>
-    </WorkspaceWithMobileNav>
+    <SettingsPageContent
+      workspace={workspace}
+      initialSettings={{
+        api_key: workspaceData.api_key,
+        api_provider: workspaceData.api_provider,
+        agents_content: workspaceData.agents_content
+      }}
+    />
   )
 }

--- a/app/[slug]/settings/settings-page-content.tsx
+++ b/app/[slug]/settings/settings-page-content.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { WorkspaceWithMobileNav } from '@/components/layout/workspace-with-mobile-nav'
+import { ApiSettings } from '@/components/settings/api-settings'
+import { CommandPaletteProvider } from '@/hooks/use-command-palette'
+import dynamic from 'next/dynamic'
+
+const AppCommandPalette = dynamic(
+  () => import('@/components/layout/app-command-palette').then(mod => ({ default: mod.AppCommandPalette })),
+  { ssr: false }
+)
+
+interface SettingsPageContentProps {
+  workspace: {
+    id: string
+    name: string
+    slug: string
+    avatar_url: string | null
+    owner_id: string
+  }
+  initialSettings: {
+    api_key?: string | null
+    api_provider?: string | null
+    agents_content?: string | null
+  }
+}
+
+export function SettingsPageContent({ workspace, initialSettings }: SettingsPageContentProps) {
+  // Filter out null values
+  const settings: { api_key?: string; api_provider?: string; agents_content?: string } = {}
+  if (initialSettings.api_key) settings.api_key = initialSettings.api_key
+  if (initialSettings.api_provider) settings.api_provider = initialSettings.api_provider
+  if (initialSettings.agents_content) settings.agents_content = initialSettings.agents_content
+
+  return (
+    <CommandPaletteProvider>
+      <WorkspaceWithMobileNav workspace={workspace}>
+        <div className="max-w-4xl mx-auto p-6">
+          <div className="mb-8">
+            <h1 className="text-2xl font-bold mb-2">Workspace Settings</h1>
+            <p className="text-gray-600">Manage your workspace configuration and integrations</p>
+          </div>
+          
+          <ApiSettings 
+            workspaceId={workspace.id}
+            initialSettings={settings}
+          />
+        </div>
+      </WorkspaceWithMobileNav>
+      {workspace && <AppCommandPalette workspace={workspace} />}
+    </CommandPaletteProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- Fixed the Settings page error: "useCommandPalette must be used within CommandPaletteProvider"
- Created a client component wrapper to properly handle CommandPaletteProvider context
- Resolved TypeScript type issues with null values in API settings

## Changes
1. Created `settings-page-content.tsx` as a client component wrapper
2. Moved dynamic imports and CommandPaletteProvider to the client component
3. Added proper null value handling when passing data to ApiSettings component
4. Maintained all existing functionality while fixing the error

## Test Results
- ✅ All tests pass (475 tests)
- ✅ TypeScript type checking passes
- ✅ ESLint passes (warnings only, no errors)
- ✅ Build succeeds

## Additional Context
The issue occurred because the Settings page is a Server Component, but `dynamic` with `ssr: false` can only be used in Client Components. The solution was to create a client component wrapper that handles all client-side logic including the CommandPaletteProvider context and dynamic imports.

🤖 Generated with [Claude Code](https://claude.ai/code)