### PR TITLE
Add Gmail link on email confirmation page for Gmail users

### DIFF
--- a/app/checkemail/page.tsx
+++ b/app/checkemail/page.tsx
@@ -11,6 +11,7 @@ export default async function CheckEmailPage(props: {
 }) {
   const searchParams = await props.searchParams
   const email = searchParams.email
+  const isGmailUser = email?.toLowerCase().endsWith('@gmail.com')
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 md:p-6 lg:p-8">
@@ -46,6 +47,28 @@ export default async function CheckEmailPage(props: {
             )}
           </p>
         </div>
+
+        {/* Gmail Link for Gmail Users */}
+        {isGmailUser && (
+          <div className="pt-4">
+            <a
+              href="https://mail.google.com/mail/u/0/#inbox"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground font-medium rounded-lg hover:bg-primary/90 transition-colors"
+            >
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"/>
+              </svg>
+              Open Gmail
+            </a>
+          </div>
+        )}
 
         {/* Additional Instructions */}
         <div className="bg-muted/30 rounded-lg p-6 space-y-4">


### PR DESCRIPTION
## Summary
- Adds a direct link to Gmail inbox on the email confirmation page for users with Gmail addresses
- Enhances user experience by providing quick access to Gmail for email verification

## Changes

### UI Updates
- Added a check to detect if the email ends with `@gmail.com` (case-insensitive)
- Displayed a styled button linking to Gmail inbox (`https://mail.google.com/mail/u/0/#inbox`) for Gmail users
- Included a Gmail icon SVG inside the button for visual identification

### Code Modifications
- Updated `app/checkemail/page.tsx` to include the new Gmail link component conditionally

## Test plan
- [x] Verify that the Gmail link appears only for emails ending with `@gmail.com`
- [x] Confirm the link opens Gmail inbox in a new tab
- [x] Check the button styling and icon display
- [x] Ensure no impact on non-Gmail users' experience

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fefa4fae-2cc0-4e35-8c1a-90697a274ebd