### PR TITLE
Conditionally render toggle commands in CommandPalette

### DIFF
--- a/components/command-palette/command-palette.tsx
+++ b/components/command-palette/command-palette.tsx
@@ -292,25 +292,29 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
     })
 
     // View Section
-    baseCommands.push({
-      id: "toggle-view",
-      title: "Toggle List/Kanban View",
-      icon: <LayoutGrid className="w-4 h-4" />,
-      shortcut: "⌘B",
-      action: handleToggleViewMode,
-      keywords: ["view", "switch", "kanban", "list", "board", "toggle"],
-      group: "View"
-    })
+    if (onToggleViewMode) {
+      baseCommands.push({
+        id: "toggle-view",
+        title: "Toggle List/Kanban View",
+        icon: <LayoutGrid className="w-4 h-4" />,
+        shortcut: "⌘B",
+        action: handleToggleViewMode,
+        keywords: ["view", "switch", "kanban", "list", "board", "toggle"],
+        group: "View"
+      })
+    }
 
-    baseCommands.push({
-      id: "toggle-search",
-      title: "Toggle Search Bar",
-      icon: <Search className="w-4 h-4" />,
-      shortcut: "/",
-      action: handleToggleSearch,
-      keywords: ["search", "find", "filter", "query", "toggle", "show", "hide"],
-      group: "View"
-    })
+    if (onToggleSearch) {
+      baseCommands.push({
+        id: "toggle-search",
+        title: "Toggle Search Bar",
+        icon: <Search className="w-4 h-4" />,
+        shortcut: "/",
+        action: handleToggleSearch,
+        keywords: ["search", "find", "filter", "query", "toggle", "show", "hide"],
+        group: "View"
+      })
+    }
 
     // Filter by Status Section - Only show when in list view
     const currentView = getCurrentView?.()
@@ -473,7 +477,7 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
         title: "General",
         shortcuts: [
           { keys: ["⌘", "K"], description: "Open command palette" },
-          { keys: ["/"], description: "Toggle search bar" },
+          ...(onToggleSearch ? [{ keys: ["/"], description: "Toggle search bar" }] : []),
           { keys: ["Esc"], description: "Close dialogs and cancel actions" },
         ]
       },
@@ -495,12 +499,12 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
           { keys: ["S", "then", "D"], description: "Change status to Done" },
         ]
       }] : []),
-      {
+      ...(onToggleViewMode ? [{
         title: "View",
         shortcuts: [
           { keys: ["⌘", "B"], description: "Toggle List/Kanban view" },
         ]
-      },
+      }] : []),
       {
         title: "Command Palette",
         shortcuts: [


### PR DESCRIPTION
## Summary
- Adds conditional rendering for toggle commands in the CommandPalette component
- Only shows "Toggle List/Kanban View" if `onToggleViewMode` prop is provided
- Only shows "Toggle Search Bar" if `onToggleSearch` prop is provided
- Updates keyboard shortcut help sections to reflect the presence of these toggle commands

## Changes

### CommandPalette Component
- Wrapped the "Toggle List/Kanban View" command in a conditional check for `onToggleViewMode`
- Wrapped the "Toggle Search Bar" command in a conditional check for `onToggleSearch`
- Updated the keyboard shortcuts help section to conditionally include shortcuts for toggling view and search bar based on the presence of respective props

## Test plan
- Verify that the toggle view command appears only when `onToggleViewMode` is passed
- Verify that the toggle search command appears only when `onToggleSearch` is passed
- Confirm keyboard shortcuts help updates accordingly
- Test toggling view and search bar functionality when commands are present

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b5e70554-ba7c-41c8-ae7d-eacaa92c88c1