### PR TITLE
feat: Implement multiple workspaces with workspace switching

### DIFF
--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,32 +1,27 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import { LoadingSpinner } from '@/components/ui/loading-spinner'
 
 export default async function WorkspaceLoadingPage() {
   const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-
-  console.log('[WorkspaceLoadingPage] Auth check:', { userId: user?.id, authError })
+  const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
     redirect('/')
   }
 
   // Check user profile
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile } = await supabase
     .from('users')
     .select('id')
     .eq('id', user.id)
     .single()
-
-  console.log('[WorkspaceLoadingPage] Profile check:', { profile, profileError })
 
   if (!profile) {
     redirect('/CreateUser')
   }
 
   // Get user's first workspace from workspace_members
-  const { data: workspaceMemberships, error: workspaceError } = await supabase
+  const { data: workspaceMemberships } = await supabase
     .from('workspace_members')
     .select(`
       workspace:workspaces!inner(
@@ -37,24 +32,12 @@ export default async function WorkspaceLoadingPage() {
     .order('created_at', { ascending: true })
     .limit(1)
 
-  console.log('[WorkspaceLoadingPage] Workspace memberships:', { 
-    workspaceMemberships, 
-    workspaceError,
-    rawData: JSON.stringify(workspaceMemberships, null, 2)
-  })
-
   if (!workspaceMemberships || workspaceMemberships.length === 0) {
-    console.log('[WorkspaceLoadingPage] No workspaces found, redirecting to CreateWorkspace')
     redirect('/CreateWorkspace')
   }
 
   // The query returns an object with a 'workspace' property
-  const membership = workspaceMemberships[0] as any
-  console.log('[WorkspaceLoadingPage] Membership data:', {
-    membership,
-    hasWorkspace: !!membership?.workspace,
-    workspaceType: typeof membership?.workspace
-  })
+  const membership = workspaceMemberships[0] as { workspace?: { slug: string } | Array<{ slug: string }> }
 
   // Handle both array and object formats for workspace
   let workspaceSlug: string | undefined
@@ -62,22 +45,15 @@ export default async function WorkspaceLoadingPage() {
     if (Array.isArray(membership.workspace) && membership.workspace[0]?.slug) {
       // Handle array format (some queries return workspace as array)
       workspaceSlug = membership.workspace[0].slug
-    } else if (membership.workspace.slug) {
-      // Handle object format (most queries return workspace as object)
+    } else if (!Array.isArray(membership.workspace) && membership.workspace.slug) {
+      // Handle object format (most queries return workspace as object)  
       workspaceSlug = membership.workspace.slug
     }
   }
 
   if (workspaceSlug) {
-    console.log('[WorkspaceLoadingPage] Redirecting to workspace:', workspaceSlug)
     redirect(`/${workspaceSlug}`)
   }
-
-  // Log the unexpected data structure
-  console.error('[WorkspaceLoadingPage] Could not find workspace slug:', {
-    membership,
-    workspace: membership?.workspace
-  })
 
   // Fallback - redirect to create workspace if we can't find a valid workspace
   redirect('/CreateWorkspace')

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,29 +1,32 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
-import type { WorkspaceMemberSlugQueryResponse } from '@/types/supabase-helpers'
 
 export default async function WorkspaceLoadingPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+  console.log('[WorkspaceLoadingPage] Auth check:', { userId: user?.id, authError })
 
   if (!user) {
     redirect('/')
   }
 
   // Check user profile
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('users')
     .select('id')
     .eq('id', user.id)
     .single()
+
+  console.log('[WorkspaceLoadingPage] Profile check:', { profile, profileError })
 
   if (!profile) {
     redirect('/CreateUser')
   }
 
   // Get user's first workspace from workspace_members
-  const { data: workspaceMemberships } = await supabase
+  const { data: workspaceMemberships, error: workspaceError } = await supabase
     .from('workspace_members')
     .select(`
       workspace:workspaces!inner(
@@ -34,24 +37,48 @@ export default async function WorkspaceLoadingPage() {
     .order('created_at', { ascending: true })
     .limit(1)
 
+  console.log('[WorkspaceLoadingPage] Workspace memberships:', { 
+    workspaceMemberships, 
+    workspaceError,
+    rawData: JSON.stringify(workspaceMemberships, null, 2)
+  })
 
   if (!workspaceMemberships || workspaceMemberships.length === 0) {
+    console.log('[WorkspaceLoadingPage] No workspaces found, redirecting to CreateWorkspace')
     redirect('/CreateWorkspace')
-  } else if (workspaceMemberships[0]) {
-    const membership = workspaceMemberships[0] as WorkspaceMemberSlugQueryResponse
-    const workspace = membership.workspace[0]
-    if (workspace) {
-      redirect(`/${workspace.slug}`)
+  }
+
+  // The query returns an object with a 'workspace' property
+  const membership = workspaceMemberships[0] as any
+  console.log('[WorkspaceLoadingPage] Membership data:', {
+    membership,
+    hasWorkspace: !!membership?.workspace,
+    workspaceType: typeof membership?.workspace
+  })
+
+  // Handle both array and object formats for workspace
+  let workspaceSlug: string | undefined
+  if (membership?.workspace) {
+    if (Array.isArray(membership.workspace) && membership.workspace[0]?.slug) {
+      // Handle array format (some queries return workspace as array)
+      workspaceSlug = membership.workspace[0].slug
+    } else if (membership.workspace.slug) {
+      // Handle object format (most queries return workspace as object)
+      workspaceSlug = membership.workspace.slug
     }
   }
 
-  // Fallback (should not reach here)
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center space-y-4">
-        <LoadingSpinner />
-        <p className="text-muted-foreground">Loading your workspace...</p>
-      </div>
-    </div>
-  )
+  if (workspaceSlug) {
+    console.log('[WorkspaceLoadingPage] Redirecting to workspace:', workspaceSlug)
+    redirect(`/${workspaceSlug}`)
+  }
+
+  // Log the unexpected data structure
+  console.error('[WorkspaceLoadingPage] Could not find workspace slug:', {
+    membership,
+    workspace: membership?.workspace
+  })
+
+  // Fallback - redirect to create workspace if we can't find a valid workspace
+  redirect('/CreateWorkspace')
 }

--- a/components/layout/workspace-with-mobile-nav.tsx
+++ b/components/layout/workspace-with-mobile-nav.tsx
@@ -68,10 +68,28 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
         console.error('Error fetching workspaces:', workspacesError)
       }
       
+      console.log('[WorkspaceWithMobileNav] Workspaces data:', {
+        workspacesData,
+        rawData: JSON.stringify(workspacesData, null, 2)
+      })
+      
       if (workspacesData) {
         const transformedWorkspaces = workspacesData
-          .map((item: WorkspaceMemberQueryResponse) => {
-            const workspace = item.workspace[0]
+          .map((item: any) => {
+            console.log('[WorkspaceWithMobileNav] Processing item:', {
+              item,
+              workspace: item.workspace,
+              isArray: Array.isArray(item.workspace)
+            })
+            
+            // Handle both array and object formats for workspace
+            let workspace: any
+            if (Array.isArray(item.workspace)) {
+              workspace = item.workspace[0]
+            } else {
+              workspace = item.workspace
+            }
+            
             if (!workspace) return null
             return {
               id: workspace.id,
@@ -83,6 +101,8 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
             }
           })
           .filter((workspace): workspace is UserWorkspace => workspace !== null)
+        
+        console.log('[WorkspaceWithMobileNav] Transformed workspaces:', transformedWorkspaces)
         setWorkspaces(transformedWorkspaces)
       }
     }

--- a/components/layout/workspace-with-mobile-nav.tsx
+++ b/components/layout/workspace-with-mobile-nav.tsx
@@ -6,7 +6,6 @@ import { Header } from './header'
 import { WorkspaceLayout } from './workspace-layout'
 import { useWorkspaceNavigation } from '@/hooks/use-workspace-navigation'
 import type { UserWorkspace } from '@/lib/supabase/workspaces'
-import type { WorkspaceMemberQueryResponse } from '@/types/supabase-helpers'
 
 interface WorkspaceWithMobileNavProps {
   workspace: {
@@ -68,22 +67,16 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
         console.error('Error fetching workspaces:', workspacesError)
       }
       
-      console.log('[WorkspaceWithMobileNav] Workspaces data:', {
-        workspacesData,
-        rawData: JSON.stringify(workspacesData, null, 2)
-      })
-      
       if (workspacesData) {
         const transformedWorkspaces = workspacesData
-          .map((item: any) => {
-            console.log('[WorkspaceWithMobileNav] Processing item:', {
-              item,
-              workspace: item.workspace,
-              isArray: Array.isArray(item.workspace)
-            })
-            
+          .map((item: { 
+            workspace: { id: string; name: string; slug: string; avatar_url: string | null } | 
+                      Array<{ id: string; name: string; slug: string; avatar_url: string | null }>;
+            role: string;
+            created_at: string;
+          }) => {
             // Handle both array and object formats for workspace
-            let workspace: any
+            let workspace: { id: string; name: string; slug: string; avatar_url: string | null } | undefined
             if (Array.isArray(item.workspace)) {
               workspace = item.workspace[0]
             } else {
@@ -102,7 +95,6 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
           })
           .filter((workspace): workspace is UserWorkspace => workspace !== null)
         
-        console.log('[WorkspaceWithMobileNav] Transformed workspaces:', transformedWorkspaces)
         setWorkspaces(transformedWorkspaces)
       }
     }

--- a/lib/supabase/workspaces.ts
+++ b/lib/supabase/workspaces.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@/lib/supabase/server'
-import type { WorkspaceMemberQueryResponse } from '@/types/supabase-helpers'
 
 export interface UserWorkspace {
   id: string
@@ -40,8 +39,20 @@ export async function getUserWorkspaces(): Promise<UserWorkspace[]> {
   }
 
   // Transform the data to flatten the workspace object
-  return data?.map((item: WorkspaceMemberQueryResponse) => {
-    const workspace = item.workspace[0]
+  return data?.map((item: { 
+    workspace: { id: string; name: string; slug: string; avatar_url: string | null } | 
+              Array<{ id: string; name: string; slug: string; avatar_url: string | null }>;
+    role: string;
+    created_at: string;
+  }) => {
+    // Handle both array and object formats for workspace
+    let workspace: { id: string; name: string; slug: string; avatar_url: string | null } | undefined
+    if (Array.isArray(item.workspace)) {
+      workspace = item.workspace[0]
+    } else {
+      workspace = item.workspace
+    }
+    
     if (!workspace) return null
     return {
       id: workspace.id,

--- a/types/supabase-helpers.ts
+++ b/types/supabase-helpers.ts
@@ -13,7 +13,9 @@ export interface WorkspaceMemberWithWorkspace {
 export interface WorkspaceMemberWithSlug {
   workspace: {
     slug: string
-  }
+  } | Array<{
+    slug: string
+  }>
 }
 
 export interface WorkspaceMemberWithDetails {
@@ -21,7 +23,11 @@ export interface WorkspaceMemberWithDetails {
     name: string
     slug: string
     avatar_url: string | null
-  }
+  } | Array<{
+    name: string
+    slug: string
+    avatar_url: string | null
+  }>
 }
 
 // Raw query response types (what Supabase actually returns)


### PR DESCRIPTION
## Summary

This PR implements a multiple workspaces feature that allows users to belong to multiple workspaces and switch between them easily.

### Key Features:
- Users can now be members of multiple workspaces (not just owners)
- Added workspace switcher dropdown in the sidebar for easy workspace switching
- Modal-based workspace creation (AJAX-like, no page reload)
- Updated all queries to use `workspace_members` table instead of `owner_id`
- Fixed data structure handling for Supabase joins (supports both array and object formats)

### Changes Made:

1. **Database Integration**:
   - Leveraged existing `workspace_members` table for multi-workspace support
   - Updated RLS policies to allow users to view their workspace memberships
   - Modified all workspace queries to check membership instead of ownership

2. **UI Components**:
   - Created `WorkspaceSwitcher` component with dropdown for workspace selection
   - Added `CreateWorkspaceModal` for inline workspace creation
   - Integrated workspace switcher into the sidebar (both expanded and collapsed states)

3. **Middleware & Routing**:
   - Updated middleware to check `workspace_members` instead of `owner_id`
   - Fixed routing logic to support users who are members but not owners

4. **Bug Fixes**:
   - Fixed infinite loading spinner on workspace page
   - Fixed "Loading workspaces..." issue in sidebar dropdown
   - Handled Supabase `\!inner` join returning objects instead of arrays
   - Added proper TypeScript types for all Supabase queries

### Testing:
- Tested workspace creation flow
- Verified workspace switching functionality
- Confirmed proper loading of workspace-specific issues
- Ensured backward compatibility with existing single-workspace users

### Screenshots:
The workspace switcher appears in the sidebar with:
- Current workspace display with avatar
- Dropdown showing all user's workspaces
- "Create new workspace" option at the bottom

🤖 Generated with [Claude Code](https://claude.ai/code)