### PR TITLE
Hide issue creation timestamps on mobile views

### DIFF
--- a/components/issues/issues-list.tsx
+++ b/components/issues/issues-list.tsx
@@ -476,8 +476,8 @@ export function IssuesList({
                     </div>
                   )}
                   
-                  {/* Created Date */}
-                  <span className="text-gray-400 ml-2">
+                  {/* Created Date - Hidden on mobile */}
+                  <span className="hidden sm:inline text-gray-400 ml-2">
                     {formatDistanceToNow(new Date(issue.created_at), { addSuffix: true })}
                   </span>
                 </div>

--- a/components/issues/kanban-board.tsx
+++ b/components/issues/kanban-board.tsx
@@ -350,7 +350,7 @@ export function KanbanBoard({
                         </p>
                       )}
                       
-                      <div className="flex items-center justify-end text-xs text-gray-500">
+                      <div className="hidden sm:flex items-center justify-end text-xs text-gray-500">
                         <span>{formatDistanceToNow(new Date(issue.created_at), { addSuffix: true })}</span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Hides the creation date timestamps for issues on mobile devices
- Ensures timestamps are only visible on screen sizes `sm` and above

## Changes

### UI Components
- **IssuesList Component**: Wrapped the created date timestamp in a `span` with `hidden sm:inline` classes to hide it on mobile
- **KanbanBoard Component**: Changed the timestamp container's class to `hidden sm:flex` to hide it on mobile

## Test plan
- [x] Verify that issue creation timestamps are not visible on mobile screen sizes
- [x] Confirm timestamps appear correctly on tablet and desktop screen sizes
- [x] Check that no layout shifts occur due to the visibility changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/435dc592-4d8d-4c65-ab60-90dd5e985563