### PR TITLE
Hide info icon on mobile in workspace layout

### DIFF
--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -261,8 +261,8 @@ export function WorkspaceLayout({
         )}
       </nav>
 
-      {/* Info Icon at Bottom */}
-      <div className="p-2 border-t border-gray-200">
+      {/* Info Icon at Bottom - Hidden on mobile */}
+      <div className="hidden md:block p-2 border-t border-gray-200">
         <button
           data-sidebar-item
           onClick={() => openWithMode('help')}


### PR DESCRIPTION
## Summary
- Hides the info icon at the bottom of the workspace layout on mobile devices

## Changes

### UI Components
- Updated the `WorkspaceLayout` component to add `hidden md:block` classes to the info icon container
- This change ensures the info icon is only visible on medium and larger screens, improving mobile UI cleanliness

## Test plan
- [x] Verify the info icon is visible on desktop and tablet screen sizes
- [x] Confirm the info icon is hidden on mobile screen sizes
- [x] Check that clicking the info icon still triggers the help mode as expected on non-mobile devices

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/83448a78-2d03-4316-8da0-9ef1a73340e7