### PR TITLE
Add Recipe View and Navigation to WorkspaceContent and Cookbook

### DIFF
--- a/components/command-palette/command-palette.tsx
+++ b/components/command-palette/command-palette.tsx
@@ -38,7 +38,7 @@ interface CommandPaletteProps {
   onToggleViewMode?: () => void
   onToggleSearch?: () => void
   onSetStatusFilter?: (status: string) => void
-  getCurrentView?: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'settings'
+  getCurrentView?: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe' | 'settings'
   currentIssue?: {
     id: string
     title: string

--- a/components/cookbook/cookbook.tsx
+++ b/components/cookbook/cookbook.tsx
@@ -11,9 +11,10 @@ import { useArrowNavigation } from '@/hooks/use-arrow-navigation'
 interface CookbookProps {
   workspaceId: string
   workspaceSlug: string
+  onRecipeClick?: (recipeId: string) => void
 }
 
-export function Cookbook({ workspaceId, workspaceSlug }: CookbookProps) {
+export function Cookbook({ workspaceId, workspaceSlug, onRecipeClick }: CookbookProps) {
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useState('')
   const [tagFilter, setTagFilter] = useState('all')
@@ -47,7 +48,7 @@ export function Cookbook({ workspaceId, workspaceSlug }: CookbookProps) {
     onEnter: (element) => {
       const recipeId = element.getAttribute('data-recipe-id')
       if (recipeId) {
-        router.push(`/${workspaceSlug}/recipe/${recipeId}`)
+        handleRecipeClick(recipeId)
       }
     },
     onEscape: () => {
@@ -78,7 +79,11 @@ export function Cookbook({ workspaceId, workspaceSlug }: CookbookProps) {
   }, [focusItem])
 
   const handleRecipeClick = (recipeId: string) => {
-    router.push(`/${workspaceSlug}/recipe/${recipeId}`)
+    if (onRecipeClick) {
+      onRecipeClick(recipeId)
+    } else {
+      router.push(`/${workspaceSlug}/recipe/${recipeId}`)
+    }
   }
 
   return (

--- a/components/layout/app-command-palette.tsx
+++ b/components/layout/app-command-palette.tsx
@@ -17,7 +17,7 @@ interface AppCommandPaletteProps {
   onToggleViewMode?: () => void
   onToggleSearch?: () => void
   onSetStatusFilter?: (status: string) => void
-  getCurrentView?: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'settings'
+  getCurrentView?: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe' | 'settings'
   onNavigateToIssues?: () => void
   onNavigateToInbox?: () => void
 }

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -46,6 +46,19 @@ const ProfileSettings = dynamic(
     loading: () => <ProfileSettingsSkeleton />
   }
 )
+const RecipeDetails = dynamic(
+  () => import('@/components/cookbook/recipe-details').then(mod => ({ default: mod.RecipeDetails })),
+  { 
+    ssr: false,
+    loading: () => (
+      <div className="flex-1 overflow-auto">
+        <div className="max-w-4xl mx-auto p-4 sm:p-6">
+          <ContentSkeleton />
+        </div>
+      </div>
+    )
+  }
+)
 import {
   Select,
   SelectContent,
@@ -66,7 +79,7 @@ interface WorkspaceContentProps {
     avatar_url: string | null
     owner_id: string
   }
-  initialView?: 'list' | 'issue' | 'inbox' | 'cookbook' | 'settings'
+  initialView?: 'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe' | 'settings'
   initialIssueId?: string
   onAvatarUpdate?: (newAvatar: string) => void
 }
@@ -81,7 +94,7 @@ export interface WorkspaceContentRef {
   toggleSearch: () => void
   isSearchVisible: () => boolean
   setStatusFilter: (status: string) => void
-  getCurrentView: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'settings'
+  getCurrentView: () => 'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe' | 'settings'
 }
 
 const statusOptions = [
@@ -120,6 +133,12 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
     return match ? match[1] : null
   }
   
+  // Extract recipe ID from URL if present
+  const getRecipeIdFromPath = () => {
+    const match = pathname.match(/\/recipe\/([a-zA-Z0-9-]+)/)
+    return match ? match[1] : null
+  }
+  
   // Determine initial view based on URL if not provided
   const getInitialView = () => {
     if (initialView !== 'list') return initialView
@@ -127,11 +146,13 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
     if (pathname.includes('/cookbook')) return 'cookbook'
     if (pathname.includes('/settings')) return 'settings'
     if (pathname.includes('/issue/')) return 'issue'
+    if (pathname.includes('/recipe/')) return 'recipe'
     return 'list'
   }
   
-  const [currentView, setCurrentView] = useState<'list' | 'issue' | 'inbox' | 'cookbook' | 'settings'>(getInitialView())
+  const [currentView, setCurrentView] = useState<'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe' | 'settings'>(getInitialView())
   const [currentIssueId, setCurrentIssueId] = useState<string | null>(initialIssueId || getIssueIdFromPath() || null)
+  const [currentRecipeId, setCurrentRecipeId] = useState<string | null>(getRecipeIdFromPath() || null)
   const [refreshKey, setRefreshKey] = useState(0)
   const [issuesViewMode, setIssuesViewMode] = useState<'list' | 'kanban'>('list')
   
@@ -168,21 +189,33 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
       if (pathname.includes('/inbox')) {
         setCurrentView('inbox')
         setCurrentIssueId(null)
+        setCurrentRecipeId(null)
       } else if (pathname.includes('/cookbook')) {
         setCurrentView('cookbook')
         setCurrentIssueId(null)
+        setCurrentRecipeId(null)
       } else if (pathname.includes('/settings')) {
         setCurrentView('settings')
         setCurrentIssueId(null)
+        setCurrentRecipeId(null)
       } else if (pathname.includes('/issue/')) {
         const issueId = getIssueIdFromPath()
         if (issueId) {
           setCurrentView('issue')
           setCurrentIssueId(issueId)
+          setCurrentRecipeId(null)
+        }
+      } else if (pathname.includes('/recipe/')) {
+        const recipeId = getRecipeIdFromPath()
+        if (recipeId) {
+          setCurrentView('recipe')
+          setCurrentRecipeId(recipeId)
+          setCurrentIssueId(null)
         }
       } else if (pathname.endsWith(`/${workspace.slug}`)) {
         setCurrentView('list')
         setCurrentIssueId(null)
+        setCurrentRecipeId(null)
       }
     }
 
@@ -236,21 +269,40 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
 
   const handleIssueClick = (issueId: string) => {
     setCurrentIssueId(issueId)
+    setCurrentRecipeId(null)
     setCurrentView('issue')
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}/issue/${issueId}`)
   }
 
+  const handleRecipeClick = (recipeId: string) => {
+    setCurrentRecipeId(recipeId)
+    setCurrentIssueId(null)
+    setCurrentView('recipe')
+    // Update URL without page refresh
+    window.history.pushState({}, '', `/${workspace.slug}/recipe/${recipeId}`)
+  }
+
   const handleBackToList = () => {
     setCurrentView('list')
     setCurrentIssueId(null)
+    setCurrentRecipeId(null)
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}`)
+  }
+
+  const handleBackToCookbook = () => {
+    setCurrentView('cookbook')
+    setCurrentRecipeId(null)
+    setCurrentIssueId(null)
+    // Update URL without page refresh
+    window.history.pushState({}, '', `/${workspace.slug}/cookbook`)
   }
 
   const handleNavigateToInbox = () => {
     setCurrentView('inbox')
     setCurrentIssueId(null)
+    setCurrentRecipeId(null)
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}/inbox`)
   }
@@ -258,6 +310,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   const handleNavigateToCookbook = () => {
     setCurrentView('cookbook')
     setCurrentIssueId(null)
+    setCurrentRecipeId(null)
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}/cookbook`)
   }
@@ -265,6 +318,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   const handleNavigateToSettings = () => {
     setCurrentView('settings')
     setCurrentIssueId(null)
+    setCurrentRecipeId(null)
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}/settings`)
   }
@@ -591,7 +645,16 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
       ) : currentView === 'inbox' ? (
         <Inbox />
       ) : currentView === 'cookbook' ? (
-        <Cookbook workspaceId={workspace.id} workspaceSlug={workspace.slug} />
+        <Cookbook 
+          workspaceId={workspace.id} 
+          workspaceSlug={workspace.slug} 
+          onRecipeClick={handleRecipeClick}
+        />
+      ) : currentView === 'recipe' && currentRecipeId ? (
+        <RecipeDetails
+          recipeId={currentRecipeId}
+          onBack={handleBackToCookbook}
+        />
       ) : currentView === 'settings' ? (
         <ProfileSettings {...(onAvatarUpdate && { onAvatarUpdate })} />
       ) : currentIssueId ? (


### PR DESCRIPTION
## Summary
- Introduces a new `recipe` view to the workspace content for displaying recipe details
- Adds dynamic loading of `RecipeDetails` component with loading skeleton
- Enhances navigation to support recipe detail view alongside existing views
- Updates `Cookbook` component to handle recipe clicks with optional callback
- Updates command palette and app command palette to recognize `recipe` as a valid view

## Changes

### WorkspaceContent
- Added `recipe` to the list of possible views and state management
- Added `currentRecipeId` state to track the selected recipe
- Implemented URL parsing to extract recipe ID and set the view accordingly
- Added handlers for navigating to recipe details and back to cookbook
- Updated rendering logic to conditionally show `RecipeDetails` when in `recipe` view

### Cookbook Component
- Added optional `onRecipeClick` prop to allow parent components to handle recipe selection
- Modified internal navigation to use `onRecipeClick` if provided, otherwise fallback to router push

### Command Palette and App Command Palette
- Extended `getCurrentView` return type to include `recipe` view

### Dynamic Imports
- Added dynamic import for `RecipeDetails` component with SSR disabled and loading skeleton

## Test plan
- [x] Navigate to a recipe detail page via URL and verify correct rendering
- [x] Click a recipe in the cookbook and verify navigation to recipe detail
- [x] Use back navigation to return to cookbook and verify URL and view update
- [x] Confirm command palette correctly identifies `recipe` as current view
- [x] Verify no regressions in existing views (list, issue, inbox, cookbook, settings)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3e5ed320-3799-4313-8013-26a4bc2a93f0