### PR TITLE
Fix blank page issue when navigating via command palette

### DIFF
--- a/components/command-palette/command-palette.tsx
+++ b/components/command-palette/command-palette.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import { useRouter } from "next/navigation"
 import { Search, FileText, Inbox, Plus, Clock, LayoutGrid, Keyboard, Sparkles, CheckCircle, Circle, Loader2 } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
 import { 
@@ -69,7 +68,6 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
       hasOnIssueStatusChange: !!onIssueStatusChange
     })
   }, [workspaceSlug, workspaceId, currentIssue, onIssueStatusChange])
-  const router = useRouter()
   const { isOpen, setIsOpen, mode } = useCommandPalette()
   const { toast } = useToast()
   const [search, setSearch] = React.useState("")
@@ -104,27 +102,23 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
   
   const handleNavigateToIssues = React.useCallback(() => {
     setIsOpen(false)
-    // Always emit the event
+    // Always emit the event - the WorkspaceContent will handle navigation
     emitNavigateToIssues()
     // If callback is provided, call it too (for backwards compatibility)
     if (onNavigateToIssues) {
       onNavigateToIssues()
-    } else {
-      router.push(`/${workspaceSlug}`)
     }
-  }, [router, workspaceSlug, onNavigateToIssues, setIsOpen])
+  }, [onNavigateToIssues, setIsOpen])
   
   const handleNavigateToInbox = React.useCallback(() => {
     setIsOpen(false)
-    // Always emit the event
+    // Always emit the event - the WorkspaceContent will handle navigation
     emitNavigateToInbox()
     // If callback is provided, call it too (for backwards compatibility)
     if (onNavigateToInbox) {
       onNavigateToInbox()
-    } else {
-      router.push(`/${workspaceSlug}/inbox`)
     }
-  }, [router, workspaceSlug, onNavigateToInbox, setIsOpen])
+  }, [onNavigateToInbox, setIsOpen])
   
   
   const handleShowRecentIssues = React.useCallback(() => {


### PR DESCRIPTION
## Summary
- Removed duplicate navigation logic in command palette that was causing blank pages
- Command palette now relies solely on event-based navigation
- Fixed navigation consistency between command palette and sidebar

## Problem
When navigating to the inbox or issues pages via the command palette, users would see a blank page. This didn't happen when using the sidebar navigation.

## Root Cause
The command palette was performing double navigation:
1. Emitting navigation events (correct approach)
2. Also calling `router.push()` for fallback (causing the issue)

The `router.push()` was navigating to routes like `/[slug]/inbox/page.tsx` which returns `null`, resulting in blank pages.

## Solution
Removed the `router.push()` fallback logic from the command palette navigation handlers. The component now only emits events which are properly handled by the `WorkspaceContent` component's internal navigation system.

## Test Plan
- [x] All existing tests pass
- [x] Command palette navigation to inbox works correctly
- [x] Command palette navigation to issues works correctly
- [x] Sidebar navigation continues to work as expected
- [x] No TypeScript errors
- [x] ESLint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)