### PR TITLE
feat: implement workspace-independent user settings page

### DIFF
--- a/app/user/layout.tsx
+++ b/app/user/layout.tsx
@@ -1,0 +1,7 @@
+export default function UserLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/user/settings/page.tsx
+++ b/app/user/settings/page.tsx
@@ -1,0 +1,105 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { UserSettingsContent } from './user-settings-content'
+
+interface Workspace {
+  id: string
+  name: string
+  slug: string
+  avatar_url: string | null
+  owner_id: string
+  userRole?: string
+}
+
+export default async function UserSettingsPage() {
+  const supabase = await createClient()
+  
+  // Get current user
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    redirect('/')
+  }
+  
+  // Get user profile
+  const { data: profile } = await supabase
+    .from('users')
+    .select('id, name, avatar_url')
+    .eq('id', user.id)
+    .single()
+  
+  if (!profile) {
+    redirect('/CreateUser')
+  }
+  
+  // Get all workspaces where user is a member (owner or otherwise)
+  const { data: workspaceMembers } = await supabase
+    .from('workspace_members')
+    .select(`
+      workspace_id,
+      role,
+      workspaces!inner (
+        id,
+        name,
+        slug,
+        avatar_url,
+        owner_id
+      )
+    `)
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+  
+  // Transform the data to a flat array of workspaces with user's role
+  let workspaces: Workspace[] = []
+  
+  if (workspaceMembers && workspaceMembers.length > 0) {
+    workspaces = workspaceMembers.map((member) => {
+      const workspace = member.workspaces as unknown as {
+        id: string
+        name: string
+        slug: string
+        avatar_url: string | null
+        owner_id: string
+      }
+      return {
+        id: workspace.id,
+        name: workspace.name,
+        slug: workspace.slug,
+        avatar_url: workspace.avatar_url,
+        owner_id: workspace.owner_id,
+        userRole: member.role
+      }
+    })
+  }
+  
+  // If no workspaces via workspace_members, check for owned workspaces directly
+  // (for backward compatibility if workspace_members isn't populated)
+  if (workspaces.length === 0) {
+    const { data: ownedWorkspaces } = await supabase
+      .from('workspaces')
+      .select('id, name, slug, avatar_url, owner_id')
+      .eq('owner_id', user.id)
+      .order('created_at', { ascending: false })
+    
+    if (ownedWorkspaces && ownedWorkspaces.length > 0) {
+      const ownedWorkspacesWithRole = ownedWorkspaces.map(ws => ({
+        ...ws,
+        userRole: 'owner'
+      }))
+      workspaces = ownedWorkspacesWithRole
+    }
+  }
+  
+  return (
+    <UserSettingsContent
+      user={{
+        id: user.id,
+        email: user.email || '',
+        profile: {
+          name: profile.name || '',
+          avatar_url: profile.avatar_url || '👤'
+        }
+      }}
+      workspaces={workspaces}
+    />
+  )
+}

--- a/app/user/settings/user-settings-content.tsx
+++ b/app/user/settings/user-settings-content.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ProfileSettings } from '@/components/settings/profile-settings'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { ArrowLeft, Building2, Plus, Settings } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+
+interface Workspace {
+  id: string
+  name: string
+  slug: string
+  avatar_url: string | null
+  owner_id: string
+  userRole?: string
+}
+
+interface UserSettingsContentProps {
+  user: {
+    id: string
+    email: string
+    profile: {
+      name: string
+      avatar_url: string
+    }
+  }
+  workspaces: Workspace[]
+}
+
+export function UserSettingsContent({ user, workspaces }: UserSettingsContentProps) {
+  const [currentAvatar, setCurrentAvatar] = useState(user.profile.avatar_url)
+  
+  // Determine a default workspace for the back button
+  const defaultWorkspace = workspaces.find(ws => ws.userRole === 'owner') || workspaces[0]
+  
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="border-b">
+        <div className="container max-w-6xl mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              {defaultWorkspace ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  asChild
+                >
+                  <Link href={`/${defaultWorkspace.slug}`}>
+                    <ArrowLeft className="mr-2 h-4 w-4" />
+                    Back to {defaultWorkspace.name}
+                  </Link>
+                </Button>
+              ) : (
+                <h1 className="text-xl font-semibold">User Settings</h1>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-2xl">{currentAvatar}</span>
+              <span className="text-sm text-muted-foreground">{user.email}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      {/* Main Content */}
+      <div className="container max-w-6xl mx-auto px-4 py-8">
+        <div className="grid gap-8 md:grid-cols-[250px_1fr]">
+          {/* Sidebar Navigation */}
+          <nav className="space-y-6">
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Settings</h3>
+              <ul className="space-y-1">
+                <li>
+                  <a
+                    href="#profile"
+                    className="flex items-center gap-2 px-3 py-2 text-sm rounded-md bg-accent text-accent-foreground"
+                  >
+                    <Settings className="h-4 w-4" />
+                    Profile
+                  </a>
+                </li>
+              </ul>
+            </div>
+            
+            <Separator />
+            
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Workspaces</h3>
+              <ul className="space-y-1">
+                {workspaces.length > 0 ? (
+                  workspaces.map((workspace) => (
+                    <li key={workspace.id}>
+                      <Link
+                        href={`/${workspace.slug}/settings`}
+                        className="flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="text-base">
+                            {workspace.avatar_url || '🏢'}
+                          </span>
+                          <span className="truncate">{workspace.name}</span>
+                        </div>
+                        {workspace.userRole && (
+                          <Badge variant="outline" className="text-xs">
+                            {workspace.userRole}
+                          </Badge>
+                        )}
+                      </Link>
+                    </li>
+                  ))
+                ) : (
+                  <li className="px-3 py-2 text-sm text-muted-foreground">
+                    No workspaces found
+                  </li>
+                )}
+                <li>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start"
+                    asChild
+                  >
+                    <Link href="/CreateWorkspace">
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create Workspace
+                    </Link>
+                  </Button>
+                </li>
+              </ul>
+            </div>
+          </nav>
+          
+          {/* Main Settings Content */}
+          <main>
+            <div id="profile">
+              <ProfileSettings onAvatarUpdate={setCurrentAvatar} />
+            </div>
+            
+            {workspaces.length === 0 && (
+              <Card className="mt-6">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Building2 className="h-5 w-5" />
+                    No Workspaces Yet
+                  </CardTitle>
+                  <CardDescription>
+                    Create your first workspace to start managing your projects and collaborate with your team.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button asChild>
+                    <Link href="/CreateWorkspace">
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create Your First Workspace
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -21,7 +21,6 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [userProfile, setUserProfile] = useState<UserProfile | null>(initialProfile || null)
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const settingsTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const router = useRouter()
   const supabase = createClient()
 
@@ -56,10 +55,6 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
     document.addEventListener('mousedown', handleClickOutside)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
-      // Clear timeout on unmount
-      if (settingsTimeoutRef.current) {
-        clearTimeout(settingsTimeoutRef.current)
-      }
     }
   }, [])
 
@@ -115,29 +110,13 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
                   <p className="text-sm font-medium text-foreground">{userProfile.name}</p>
                 </div>
                 
-                <button
-                  onClick={() => {
-                    setIsDropdownOpen(false)
-                    // Clear any existing timeout
-                    if (settingsTimeoutRef.current) {
-                      clearTimeout(settingsTimeoutRef.current)
-                    }
-                    // Click the settings button in the sidebar after a small delay to ensure dropdown closes
-                    settingsTimeoutRef.current = setTimeout(() => {
-                      const settingsButtons = document.querySelectorAll('[data-sidebar-item]')
-                      settingsButtons.forEach(button => {
-                        const span = button.querySelector('span')
-                        if (span && span.textContent === 'Settings') {
-                          (button as HTMLElement).click()
-                        }
-                      })
-                      settingsTimeoutRef.current = null
-                    }, 100)
-                  }}
+                <Link
+                  href="/user/settings"
+                  onClick={() => setIsDropdownOpen(false)}
                   className="block w-full text-left px-4 py-3 md:px-4 md:py-2 text-sm text-muted-foreground hover:bg-accent"
                 >
                   Profile Settings
-                </button>
+                </Link>
                 
                 <button
                   onClick={handleLogout}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/middleware.ts
+++ b/middleware.ts
@@ -193,7 +193,7 @@ export async function middleware(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
 
   // Protected routes that require authentication
-  const protectedRoutes = ['/success', '/CreateUser', '/CreateWorkspace']
+  const protectedRoutes = ['/success', '/CreateUser', '/CreateWorkspace', '/user']
   const isProtectedRoute = protectedRoutes.some(route => pathname.startsWith(route))
   
   // Check if this is a workspace route (not one of the special routes)
@@ -202,7 +202,8 @@ export async function middleware(request: NextRequest) {
     !pathname.startsWith('/CreateUser') && 
     !pathname.startsWith('/CreateWorkspace') && 
     !pathname.startsWith('/success') &&
-    !pathname.startsWith('/checkemail')
+    !pathname.startsWith('/checkemail') &&
+    !pathname.startsWith('/user')
 
   if ((isProtectedRoute || isWorkspaceRoute) && !user) {
     return NextResponse.redirect(new URL('/', request.url))
@@ -284,6 +285,14 @@ export async function middleware(request: NextRequest) {
       }
     }
 
+    // If accessing user settings, ensure user has profile
+    if (pathname.startsWith('/user/settings')) {
+      if (!hasProfile) {
+        return NextResponse.redirect(new URL('/CreateUser', request.url))
+      }
+      // User settings doesn't require workspace, so we can proceed
+    }
+    
     // If accessing a workspace route, ensure user has profile
     if (isWorkspaceRoute) {
       if (!hasProfile) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.5",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-toast": "^1.2.14",
@@ -2599,6 +2600,29 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-toast": "^1.2.14",


### PR DESCRIPTION
## Summary
- Implements a workspace-independent user settings page at `/user/settings`
- Fetches all workspaces where user is a member (not just owned workspaces)
- Adds graceful fallback handling for users with no workspaces

## Problem
Previously, the user settings were tied to workspace context, causing:
- 404 errors for users without owned workspaces
- Inability to see workspaces where user is a member but not owner
- Poor UX when navigating to profile settings

## Solution
1. **New User Settings Route**: Created `/user/settings` with its own layout
2. **Comprehensive Workspace Fetching**: Queries `workspace_members` table to get all workspaces
3. **Fallback Handling**: Shows "Create Your First Workspace" CTA for users without workspaces
4. **Updated Navigation**: Header now links directly to user settings instead of workspace settings

## Implementation Details
- Added new pages: `app/user/settings/page.tsx` and `user-settings-content.tsx`
- Updated `components/layout/header.tsx` to link to new settings page
- Added missing UI components (Badge, Separator)
- Updated middleware to properly handle user settings routes
- Maintains backward compatibility with existing workspace settings

## Test plan
- [x] All existing tests pass (376 tests)
- [x] TypeScript type checking passes
- [x] ESLint checks pass
- [ ] Manual testing of user settings navigation
- [ ] Verify workspace list shows all memberships
- [ ] Test fallback for users with no workspaces

🤖 Generated with [Claude Code](https://claude.ai/code)