### PR TITLE
Add mobile create issue button to header and workspace layout

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { Menu, X } from 'lucide-react'
+import { Menu, X, Plus } from 'lucide-react'
 
 interface UserProfile {
   name: string
@@ -15,9 +15,10 @@ interface HeaderProps {
   initialProfile?: UserProfile
   onMenuToggle?: () => void
   isMobileMenuOpen?: boolean
+  onCreateIssue?: () => void
 }
 
-export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: HeaderProps) {
+export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen, onCreateIssue }: HeaderProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [userProfile, setUserProfile] = useState<UserProfile | null>(initialProfile || null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -71,7 +72,7 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
     <header className="fixed top-0 left-0 right-0 bg-background border-b border-border z-50">
       <div className="w-full px-4 md:px-6 lg:px-8">
         <div className="flex items-center h-11 relative isolate">
-          {/* Left Section - Logo */}
+          {/* Left Section - Menu, Create Issue Button (Mobile), and Logo */}
           <div className="flex items-center flex-1">
             {onMenuToggle && (
               <button
@@ -86,6 +87,19 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
                 )}
               </button>
             )}
+            
+            {/* Create Issue Button - Mobile Only */}
+            {onCreateIssue && (
+              <button
+                onClick={onCreateIssue}
+                className="lg:hidden p-1.5 md:p-2 rounded-md hover:bg-accent mr-2"
+                aria-label="Create issue"
+                data-mobile-create-issue-button
+              >
+                <Plus className="h-6 w-6 text-muted-foreground" />
+              </button>
+            )}
+            
             <Link href="/daygent" className="text-xl font-bold text-foreground">
               Daygent
             </Link>

--- a/components/layout/workspace-with-mobile-nav.tsx
+++ b/components/layout/workspace-with-mobile-nav.tsx
@@ -6,6 +6,7 @@ import { Header } from './header'
 import { WorkspaceLayout } from './workspace-layout'
 import { useWorkspaceNavigation } from '@/hooks/use-workspace-navigation'
 import type { UserWorkspace } from '@/lib/supabase/workspaces'
+import { emitCreateIssueRequest } from '@/lib/events/issue-events'
 
 interface WorkspaceWithMobileNavProps {
   workspace: {
@@ -104,6 +105,11 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
     setIsMobileMenuOpen(!isMobileMenuOpen)
   }
 
+  const handleCreateIssue = () => {
+    // This will trigger the create issue modal in WorkspaceLayout
+    emitCreateIssueRequest()
+  }
+
   // Set up unified workspace navigation
   useWorkspaceNavigation({
     sidebarRef,
@@ -117,11 +123,13 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
           initialProfile={profile} 
           onMenuToggle={handleMenuToggle}
           isMobileMenuOpen={isMobileMenuOpen}
+          onCreateIssue={handleCreateIssue}
         />
       ) : (
         <Header 
           onMenuToggle={handleMenuToggle}
           isMobileMenuOpen={isMobileMenuOpen}
+          onCreateIssue={handleCreateIssue}
         />
       )}
       <div className="pt-11">


### PR DESCRIPTION
## Summary
- Adds a create issue button to the mobile header for quick issue creation
- Integrates the button with the workspace layout to trigger the create issue modal

## Changes

### Header Component
- Added a new `onCreateIssue` prop to the `Header` component
- Render a mobile-only create issue button with a plus icon next to the menu button
- Button triggers the `onCreateIssue` callback when clicked

### WorkspaceWithMobileNav Component
- Added `handleCreateIssue` function to emit a create issue request event
- Passed `handleCreateIssue` as the `onCreateIssue` prop to the `Header` component
- This enables the create issue modal to open from the mobile header button

## Test plan
- Verify the create issue button appears only on mobile view in the header
- Confirm clicking the button triggers the create issue modal
- Ensure the menu toggle and other header functionality remain unaffected
- Test navigation and issue creation flow on mobile devices

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/884eabbc-e06e-412d-9314-5bbeda405723