### PR TITLE
Remove Create Issue Button from Mobile Views

### DIFF
--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -127,15 +127,6 @@ export function WorkspaceLayout({
 
       {/* Navigation - scrollable on mobile */}
       <nav ref={sidebarRef} className="flex-1 p-1.5 md:p-2 overflow-y-auto scrollbar-thin">
-        {/* Create Issue button - mobile only */}
-        <button
-          data-sidebar-item
-          onClick={() => setCreateIssueOpen(true)}
-          className="md:hidden w-full flex items-center space-x-2 px-3 min-h-[44px] rounded-lg transition-colors hover:bg-accent text-foreground mb-1 focus:outline-none"
-        >
-          <Plus className="w-5 h-5" />
-          <span>Create Issue</span>
-        </button>
         
         {/* Search button - mobile only */}
         <button

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -14,7 +14,8 @@ import {
   subscribeToNavigateToInbox,
   subscribeToToggleViewMode,
   subscribeToToggleSearch,
-  subscribeToSetStatusFilter
+  subscribeToSetStatusFilter,
+  emitCreateIssueRequest
 } from '@/lib/events/issue-events'
 
 const KanbanBoard = dynamic(
@@ -65,7 +66,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { LayoutGrid, List, Filter, X } from 'lucide-react'
+import { LayoutGrid, List, Filter, X, Plus } from 'lucide-react'
 import { SearchBar, SearchBarRef } from '@/components/workspace/search-bar'
 import { getWorkspaceTags } from '@/lib/tags'
 import { Tag as TagComponent } from '@/components/ui/tag'
@@ -412,6 +413,16 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
           <div className="px-3 sm:px-6 py-3 sm:py-4 flex items-center justify-between gap-2 sm:gap-3">
             {/* Left side - Create issue button (mobile) and desktop filters */}
             <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
+              {/* Create Issue Button - Mobile Only */}
+              <button
+                onClick={() => emitCreateIssueRequest()}
+                className="sm:hidden flex items-center gap-1.5 px-3 py-1.5 rounded-md hover:bg-accent transition-colors text-sm font-medium"
+                title="Create issue"
+                aria-label="Create issue"
+              >
+                <Plus className="h-4 w-4" />
+                <span>Create issue</span>
+              </button>
               
               {/* Search hint when search is hidden */}
               {!isSearchVisible && !debouncedSearchQuery && (

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -14,8 +14,7 @@ import {
   subscribeToNavigateToInbox,
   subscribeToToggleViewMode,
   subscribeToToggleSearch,
-  subscribeToSetStatusFilter,
-  emitCreateIssueRequest
+  subscribeToSetStatusFilter
 } from '@/lib/events/issue-events'
 
 const KanbanBoard = dynamic(
@@ -66,7 +65,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { LayoutGrid, List, Filter, X, Plus } from 'lucide-react'
+import { LayoutGrid, List, Filter, X } from 'lucide-react'
 import { SearchBar, SearchBarRef } from '@/components/workspace/search-bar'
 import { getWorkspaceTags } from '@/lib/tags'
 import { Tag as TagComponent } from '@/components/ui/tag'
@@ -413,16 +412,6 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
           <div className="px-3 sm:px-6 py-3 sm:py-4 flex items-center justify-between gap-2 sm:gap-3">
             {/* Left side - Create issue button (mobile) and desktop filters */}
             <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
-              {/* Create Issue Button - Mobile Only */}
-              <button
-                onClick={() => emitCreateIssueRequest()}
-                className="sm:hidden flex items-center gap-1.5 px-3 py-1.5 rounded-md hover:bg-accent transition-colors text-sm font-medium"
-                title="Create issue"
-                aria-label="Create issue"
-              >
-                <Plus className="h-4 w-4" />
-                <span>Create issue</span>
-              </button>
               
               {/* Search hint when search is hidden */}
               {!isSearchVisible && !debouncedSearchQuery && (


### PR DESCRIPTION
## Summary
- Removes the "Create Issue" button from mobile views in the workspace layout and content components.
- Cleans up unused imports and event emissions related to the create issue functionality on mobile.

## Changes

### UI Components
- **WorkspaceLayout**: Deleted the mobile-only "Create Issue" button from the sidebar navigation.
- **WorkspaceContent**: Removed the mobile-only "Create Issue" button from the top bar and the associated `Plus` icon import.

### Code Cleanup
- Removed `emitCreateIssueRequest` import and usage from `workspace-content.tsx`.
- Removed `Plus` icon import from `workspace-content.tsx`.

## Test plan
- [x] Verify that the "Create Issue" button no longer appears on mobile views in the sidebar and top bar.
- [x] Confirm no regressions in desktop views or other UI elements.
- [x] Ensure no console errors related to removed event emissions or imports.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b63574e-147b-432f-91d9-f4e0ceb2834d