### PR TITLE
Fix UI clipping in issue type and status selectors; enhance test mocks

### DIFF
--- a/components/issues/issue-details.tsx
+++ b/components/issues/issue-details.tsx
@@ -611,7 +611,7 @@ export function IssueDetails({ issueId, workspaceSlug, onBack, onDeleted }: Issu
                   onValueChange={handleStatusChange}
                   disabled={isUpdatingStatus}
                 >
-                  <SelectTrigger className="h-7 w-auto border-0 p-0 hover:bg-accent focus:ring-0 focus:ring-offset-0">
+                  <SelectTrigger className="h-7 w-auto border-0 p-0 hover:bg-accent focus:ring-0 focus:ring-offset-0 [&>span]:line-clamp-none">
                     <SelectValue>
                       <span className={`text-sm font-medium ${statusOptions.find(s => s.value === issue.status)?.color || 'text-muted-foreground'}`}>
                         {statusOptions.find(s => s.value === issue.status)?.label || issue.status}
@@ -634,7 +634,7 @@ export function IssueDetails({ issueId, workspaceSlug, onBack, onDeleted }: Issu
                   onValueChange={handleTypeChange}
                   disabled={isUpdatingType}
                 >
-                  <SelectTrigger className="h-7 w-auto border-0 p-0 hover:bg-accent focus:ring-0 focus:ring-offset-0">
+                  <SelectTrigger className="h-7 w-auto border-0 p-0 hover:bg-accent focus:ring-0 focus:ring-offset-0 [&>span]:line-clamp-none">
                     <SelectValue>
                       <span className="text-sm font-medium flex items-center gap-1">
                         <span>{typeOptions.find(t => t.value === issue.type)?.icon || '📌'}</span>

--- a/test/__tests__/components/issues/edit-issue-modal.test.tsx
+++ b/test/__tests__/components/issues/edit-issue-modal.test.tsx
@@ -122,7 +122,7 @@ describe('EditIssueModal - Prompt Generation', () => {
     )
     
     // Reset the mock implementation but preserve the tag-related functionality
-    mockSupabase.from.mockImplementation((table) => {
+    mockSupabase.from.mockImplementation((table: any) => {
       if (table === 'issue_tags') {
         return {
           delete: vi.fn(() => ({
@@ -147,7 +147,18 @@ describe('EditIssueModal - Prompt Generation', () => {
         return {
           update: vi.fn(() => ({
             eq: vi.fn(() => Promise.resolve({ error: null }))
-          }))
+          })),
+          select: vi.fn(() => {
+            // Support chained .eq() calls
+            const chainableQuery = {
+              eq: vi.fn(() => chainableQuery),
+              single: vi.fn(() => Promise.resolve({ 
+                data: { id: 'test-workspace-id', name: 'Test Workspace', api_key: 'test-key', api_provider: 'openai' }, 
+                error: null 
+              }))
+            }
+            return chainableQuery
+          })
         }
       }
       return {


### PR DESCRIPTION
## Summary
- Fixes UI clipping issue in the issue type and status dropdown selectors by disabling line clamping on the trigger span
- Improves test reliability by enhancing mock implementations in `edit-issue-modal.test.tsx` for chained query support

## Changes

### UI Fixes
- Updated `SelectTrigger` components in `IssueDetails` to add `[&>span]:line-clamp-none` class, preventing text clipping in status and type selectors

### Test Improvements
- Added type annotation to `mockSupabase.from` mock implementation
- Enhanced mock for chained `.eq()` calls with support for `.select()` and `.single()` to better simulate database queries in `edit-issue-modal.test.tsx`

## Test plan
- [x] Verified that issue type and status dropdowns no longer clip text in the UI
- [x] Ran updated tests in `edit-issue-modal.test.tsx` to ensure mocks behave correctly and tests pass

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5274458f-4214-42d6-99aa-be5f38e97196