### PR TITLE
Hide Inbox Navigation in Workspace Layout and Command Palette for Future Use

### DIFF
--- a/components/command-palette/command-palette.tsx
+++ b/components/command-palette/command-palette.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Search, FileText, Inbox, Plus, Clock, LayoutGrid, Keyboard, Sparkles, CheckCircle, Circle, Loader2 } from "lucide-react"
+import { Search, FileText, /* Inbox, */ Plus, Clock, LayoutGrid, Keyboard, Sparkles, CheckCircle, Circle, Loader2 } from "lucide-react"
 import { 
   emitIssueStatusUpdate, 
   emitCreateIssueRequest,
@@ -323,6 +323,7 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
       group: "Quick Access"
     })
 
+    /* Go to Inbox command - hidden for now but preserved for future use
     baseCommands.push({
       id: "go-inbox",
       title: "Go to Inbox",
@@ -332,6 +333,7 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
       keywords: ["navigate", "triage", "inbox"],
       group: "Quick Access"
     })
+    */
 
     // View Section
     baseCommands.push({

--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -36,7 +36,7 @@ interface WorkspaceLayoutProps {
   children: React.ReactNode
   onIssueCreated?: () => void
   onNavigateToIssues?: () => void
-  onNavigateToInbox?: () => void
+  onNavigateToInbox?: () => void // Currently hidden but preserved for future use
   onNavigateToCookbook?: () => void
   isMobileMenuOpen?: boolean
   setIsMobileMenuOpen?: (open: boolean) => void
@@ -49,6 +49,7 @@ export function WorkspaceLayout({
   children, 
   onIssueCreated, 
   onNavigateToIssues,
+  // @ts-expect-error - Currently hidden but preserved for future use
   onNavigateToInbox,
   onNavigateToCookbook,
   isMobileMenuOpen: propIsMobileMenuOpen,
@@ -141,6 +142,7 @@ export function WorkspaceLayout({
           <span>Search</span>
         </button>
         
+        {/* Inbox navigation - hidden for now but preserved for future use
         {onNavigateToInbox ? (
           <button
             data-sidebar-item
@@ -172,6 +174,7 @@ export function WorkspaceLayout({
             <span>Inbox</span>
           </Link>
         )}
+        */}
         
         {onNavigateToIssues ? (
           <button
@@ -311,6 +314,7 @@ export function WorkspaceLayout({
               >
                 <Plus className="w-5 h-5 text-muted-foreground" />
               </button>
+              {/* Inbox icon button - hidden for now but preserved for future use
               {onNavigateToInbox ? (
                 <button
                   onClick={onNavigateToInbox}
@@ -338,6 +342,7 @@ export function WorkspaceLayout({
                   </svg>
                 </Link>
               )}
+              */}
               {onNavigateToIssues ? (
                 <button
                   onClick={onNavigateToIssues}

--- a/hooks/use-global-shortcuts.tsx
+++ b/hooks/use-global-shortcuts.tsx
@@ -200,6 +200,7 @@ export function useGlobalShortcuts({
         },
         description: 'Go to issues',
       },
+      /* Go to inbox shortcut - hidden for now but preserved for future use
       'gn': {
         handler: () => {
           if (onNavigateToInbox) {
@@ -211,6 +212,7 @@ export function useGlobalShortcuts({
         },
         description: 'Go to inbox',
       },
+      */
       
       // Sequential shortcuts - Status changes
       'st': {

--- a/test/__tests__/user-experience/command-palette.test.tsx
+++ b/test/__tests__/user-experience/command-palette.test.tsx
@@ -124,18 +124,18 @@ describe('Command Palette (Simplified)', () => {
       
       await user.click(screen.getByText('Open Command Palette'))
       
-      // All commands visible initially
+      // All commands visible initially (except hidden inbox command)
       expect(screen.getByText('Go to Issues')).toBeInTheDocument()
-      expect(screen.getByText('Go to Inbox')).toBeInTheDocument()
+      expect(screen.queryByText('Go to Inbox')).not.toBeInTheDocument() // Inbox command is hidden
       expect(screen.getByText('New Issue')).toBeInTheDocument()
       
-      // Search
+      // Search for issues instead since inbox is hidden
       const searchInput = screen.getByPlaceholderText('Type a command or search...')
-      await user.type(searchInput, 'inbox')
+      await user.type(searchInput, 'issues')
       
-      // Only inbox command visible
-      expect(screen.queryByText('Go to Issues')).not.toBeInTheDocument()
-      expect(screen.getByText('Go to Inbox')).toBeInTheDocument()
+      // Only issues command visible
+      expect(screen.getByText('Go to Issues')).toBeInTheDocument()
+      expect(screen.queryByText('Go to Inbox')).not.toBeInTheDocument()
       expect(screen.queryByText('New Issue')).not.toBeInTheDocument()
     })
 

--- a/test/__tests__/user-experience/navigation.test.tsx
+++ b/test/__tests__/user-experience/navigation.test.tsx
@@ -113,19 +113,20 @@ describe('Navigation', () => {
       expect(mockRouter.push).toHaveBeenCalledWith('/test-workspace')
     })
 
-    it('navigates to inbox with G then N', async () => {
-      render(
-        <TestWrapper>
-          <TestComponent workspaceSlug="test-workspace" />
-        </TestWrapper>
-      )
+    // Inbox navigation is currently hidden - test disabled
+    // it('navigates to inbox with G then N', async () => {
+    //   render(
+    //     <TestWrapper>
+    //       <TestComponent workspaceSlug="test-workspace" />
+    //     </TestWrapper>
+    //   )
 
-      // Press G then N
-      await user.keyboard('g')
-      await user.keyboard('n')
+    //   // Press G then N
+    //   await user.keyboard('g')
+    //   await user.keyboard('n')
 
-      expect(mockRouter.push).toHaveBeenCalledWith('/test-workspace/inbox')
-    })
+    //   expect(mockRouter.push).toHaveBeenCalledWith('/test-workspace/inbox')
+    // })
 
     it('creates new issue with C key', async () => {
       const { getByText } = render(
@@ -424,11 +425,11 @@ describe('Navigation', () => {
 
       const startTime = performance.now()
 
-      // Rapid keyboard navigation
+      // Rapid keyboard navigation (inbox navigation gn is disabled, so only gi works)
       await user.keyboard('g')
       await user.keyboard('i')
       await user.keyboard('g')
-      await user.keyboard('n')
+      await user.keyboard('n') // This no longer triggers navigation
       await user.keyboard('g')
       await user.keyboard('i')
 
@@ -437,8 +438,8 @@ describe('Navigation', () => {
       // Should handle rapid navigation within 100ms
       expect(endTime - startTime).toBeLessThan(100)
 
-      // Should have navigated 3 times
-      expect(mockRouter.push).toHaveBeenCalledTimes(3)
+      // Should have navigated 2 times (only gi shortcuts work, gn is disabled)
+      expect(mockRouter.push).toHaveBeenCalledTimes(2)
     })
 
     it('debounces navigation calls', async () => {


### PR DESCRIPTION
## Summary
- Temporarily hides the Inbox navigation elements in the workspace layout and command palette
- Preserves the Inbox navigation code and shortcuts for potential future reactivation
- Adds comments and TypeScript expect-error to clarify the current hidden state

## Changes

### Workspace Layout Component
- Commented out the Inbox navigation button and link in the sidebar
- Commented out the Inbox icon button in the mobile menu
- Added `// @ts-expect-error` to the `onNavigateToInbox` prop to suppress TypeScript errors since it's currently unused
- Added inline comments explaining that the Inbox navigation is hidden but preserved for future use

### Command Palette
- Commented out the Inbox command in the command palette commands list

### Global Shortcuts
- Commented out the Inbox navigation shortcut handlers

### Tests
- Updated tests to reflect that the Inbox command and shortcuts are hidden
- Disabled the navigation test for Inbox shortcut since it is currently hidden
- Adjusted expectations in navigation tests to account for disabled Inbox navigation shortcut

## Test plan
- Verified that the Inbox navigation buttons and links do not appear in the UI
- Confirmed no TypeScript errors related to the hidden `onNavigateToInbox` prop
- Ensured other navigation elements (Issues, Cookbook) remain functional and visible
- Verified that the Inbox command is not visible in the command palette
- Confirmed that the Inbox navigation shortcut is disabled and tests reflect this

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e3e1a2b5-acda-4edc-87bf-fb77ebf95be5