### PR TITLE
Enhance sidebar collapse toggle visibility on hover

### DIFF
--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -59,6 +59,7 @@ export function WorkspaceLayout({
   const [createIssueOpen, setCreateIssueOpen] = useState(false)
   const [localIsMobileMenuOpen, setLocalIsMobileMenuOpen] = useState(false)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  const [isSidebarHovered, setIsSidebarHovered] = useState(false)
   const pathname = usePathname()
   const { openWithMode } = useCommandPalette()
   const localSidebarRef = useRef<HTMLDivElement>(null)
@@ -280,15 +281,21 @@ export function WorkspaceLayout({
     <>
       <div className="flex h-screen bg-background">
         {/* Desktop Sidebar */}
-        <div className={`hidden lg:flex bg-sidebar border-r border-border flex-col relative transition-all duration-300 ${
-          isSidebarCollapsed ? 'w-16' : 'w-[224px]'
-        }`}>
+        <div 
+          className={`hidden lg:flex bg-sidebar border-r border-border flex-col relative transition-all duration-300 ${
+            isSidebarCollapsed ? 'w-16' : 'w-[224px]'
+          }`}
+          onMouseEnter={() => setIsSidebarHovered(true)}
+          onMouseLeave={() => setIsSidebarHovered(false)}
+        >
           {!isSidebarCollapsed && <SidebarContent />}
           
-          {/* Collapse Toggle Button */}
+          {/* Collapse Toggle Button - Only visible on hover */}
           <button
             onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-            className="absolute -right-3 top-8 bg-background border border-border rounded-full p-1 hover:bg-accent shadow-sm z-10"
+            className={`absolute -right-3 top-8 bg-background border border-border rounded-full p-1 hover:bg-accent shadow-sm z-10 transition-opacity duration-200 ${
+              isSidebarHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            }`}
             aria-label={isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {isSidebarCollapsed ? (


### PR DESCRIPTION
## Summary
- Adds hover state to the desktop sidebar to improve UX
- Collapse toggle button now only visible when sidebar is hovered
- Sidebar width transitions smoothly between collapsed and expanded states

## Changes

### UI Components
- Introduced `isSidebarHovered` state to track mouse hover on sidebar
- Added `onMouseEnter` and `onMouseLeave` handlers to sidebar container
- Collapse toggle button opacity toggles based on hover state, with smooth transition

## Test plan
- [x] Verify sidebar expands and collapses correctly
- [x] Confirm collapse toggle button appears only on hover
- [x] Check sidebar width transitions smoothly
- [x] Ensure no regressions in sidebar functionality on desktop viewports

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/07376e56-904a-4f8f-b460-8efa0400f561