### PR TITLE
Add settings navigation and settings page integration

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -28,6 +28,10 @@ export default function WorkspacePage({ params }: { params: Promise<{ slug: stri
     contentRef.current?.navigateToCookbook()
   }
 
+  const handleNavigateToSettings = () => {
+    contentRef.current?.navigateToSettings()
+  }
+
   // These handlers were previously used with AppCommandPalette
   // which is now handled at the layout level
 
@@ -40,6 +44,7 @@ export default function WorkspacePage({ params }: { params: Promise<{ slug: stri
       onNavigateToIssues={handleNavigateToIssues}
       onNavigateToInbox={handleNavigateToInbox}
       onNavigateToCookbook={handleNavigateToCookbook}
+      onNavigateToSettings={handleNavigateToSettings}
     >
       <WorkspaceContent 
         ref={contentRef}

--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -38,6 +38,7 @@ interface WorkspaceLayoutProps {
   onNavigateToIssues?: () => void
   onNavigateToInbox?: () => void // Currently hidden but preserved for future use
   onNavigateToCookbook?: () => void
+  onNavigateToSettings?: () => void
   isMobileMenuOpen?: boolean
   setIsMobileMenuOpen?: (open: boolean) => void
   sidebarRef?: React.RefObject<HTMLDivElement | null>
@@ -52,6 +53,7 @@ export function WorkspaceLayout({
   // @ts-expect-error - Currently hidden but preserved for future use
   onNavigateToInbox,
   onNavigateToCookbook,
+  onNavigateToSettings,
   isMobileMenuOpen: propIsMobileMenuOpen,
   setIsMobileMenuOpen: propSetIsMobileMenuOpen,
   sidebarRef: propSidebarRef
@@ -248,18 +250,33 @@ export function WorkspaceLayout({
           <span>Commands</span>
         </button>
         
-        <Link
-          data-sidebar-item
-          href={`/${workspace.slug}/settings`}
-          className={`flex items-center space-x-2 md:space-x-3 px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors mt-1 focus:outline-none ${
-            pathname === `/${workspace.slug}/settings` 
-              ? 'bg-accent text-foreground' 
-              : 'hover:bg-accent text-foreground'
-          }`}
-        >
-          <Settings className="w-5 h-5" />
-          <span>Settings</span>
-        </Link>
+        {onNavigateToSettings ? (
+          <button
+            data-sidebar-item
+            onClick={onNavigateToSettings}
+            className={`w-full flex items-center space-x-2 md:space-x-3 px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors mt-1 focus:outline-none ${
+              pathname === `/${workspace.slug}/settings` 
+                ? 'bg-accent text-foreground' 
+                : 'hover:bg-accent text-foreground'
+            }`}
+          >
+            <Settings className="w-5 h-5" />
+            <span>Settings</span>
+          </button>
+        ) : (
+          <Link
+            data-sidebar-item
+            href={`/${workspace.slug}/settings`}
+            className={`flex items-center space-x-2 md:space-x-3 px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors mt-1 focus:outline-none ${
+              pathname === `/${workspace.slug}/settings` 
+                ? 'bg-accent text-foreground' 
+                : 'hover:bg-accent text-foreground'
+            }`}
+          >
+            <Settings className="w-5 h-5" />
+            <span>Settings</span>
+          </Link>
+        )}
       </nav>
 
       {/* Info Icon at Bottom - Hidden on mobile */}

--- a/components/layout/workspace-with-mobile-nav.tsx
+++ b/components/layout/workspace-with-mobile-nav.tsx
@@ -20,9 +20,10 @@ interface WorkspaceWithMobileNavProps {
   onNavigateToIssues?: () => void
   onNavigateToInbox?: () => void
   onNavigateToCookbook?: () => void
+  onNavigateToSettings?: () => void
 }
 
-export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, onNavigateToIssues, onNavigateToInbox, onNavigateToCookbook }: WorkspaceWithMobileNavProps) {
+export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, onNavigateToIssues, onNavigateToInbox, onNavigateToCookbook, onNavigateToSettings }: WorkspaceWithMobileNavProps) {
   const [profile, setProfile] = useState<{ name: string; avatar_url: string | null } | null>(null)
   const [workspaces, setWorkspaces] = useState<UserWorkspace[]>([])
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -132,6 +133,7 @@ export function WorkspaceWithMobileNav({ workspace, children, onIssueCreated, on
           {...(onNavigateToIssues && { onNavigateToIssues })}
           {...(onNavigateToInbox && { onNavigateToInbox })}
           {...(onNavigateToCookbook && { onNavigateToCookbook })}
+          {...(onNavigateToSettings && { onNavigateToSettings })}
           isMobileMenuOpen={isMobileMenuOpen}
           setIsMobileMenuOpen={setIsMobileMenuOpen}
           sidebarRef={sidebarRef}

--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { ApiSettings } from '@/components/settings/api-settings'
+import { DangerZoneSettings } from '@/components/settings/danger-zone-settings'
+import { useWorkspace } from '@/contexts/workspace-context'
+import { createClient } from '@/lib/supabase/client'
+import { useEffect, useState } from 'react'
+
+interface SettingsContentProps {
+  workspaceSlug: string
+}
+
+export function SettingsContent({ }: SettingsContentProps) {
+  const { workspace } = useWorkspace()
+  const [settings, setSettings] = useState<{
+    api_key?: string | null | undefined
+    api_provider?: string | null | undefined
+    agents_content?: string | null | undefined
+  }>({})
+  const [isOwner, setIsOwner] = useState(false)
+
+  useEffect(() => {
+    async function fetchSettings() {
+      if (!workspace) return
+      
+      const supabase = createClient()
+      const { data: { user } } = await supabase.auth.getUser()
+      
+      if (!user) return
+      
+      // Check if user is owner
+      setIsOwner(workspace.owner_id === user.id)
+      
+      // Fetch settings
+      const { data } = await supabase
+        .from('workspaces')
+        .select('api_key, api_provider, agents_content')
+        .eq('id', workspace.id)
+        .single()
+      
+      if (data) {
+        setSettings(data)
+      }
+    }
+    
+    fetchSettings()
+  }, [workspace])
+
+  if (!workspace) return null
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold mb-1">Settings</h1>
+        <p className="text-muted-foreground">
+          Manage your workspace settings and preferences
+        </p>
+      </div>
+      
+      <ApiSettings 
+        workspaceId={workspace.id}
+        {...(Object.keys(settings).length > 0 && {
+          initialSettings: {
+            ...(settings.api_key && { api_key: settings.api_key }),
+            ...(settings.api_provider && { api_provider: settings.api_provider }),
+            ...(settings.agents_content && { agents_content: settings.agents_content })
+          }
+        })}
+      />
+      
+      {isOwner && (
+        <DangerZoneSettings workspaceId={workspace.id} />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds navigation support to the Settings page within the workspace UI
- Implements a new SettingsContent component to manage workspace settings
- Integrates Settings view into workspace content with smooth transitions
- Updates workspace layout and mobile navigation to handle settings navigation

## Changes

### Navigation Enhancements
- Added `onNavigateToSettings` handler in `app/[slug]/page.tsx` and passed it down to components
- Updated `WorkspaceLayout` to conditionally render Settings button as a clickable button or link
- Extended `WorkspaceWithMobileNav` to support settings navigation

### Settings Page Implementation
- Created `SettingsContent` component to fetch and display workspace settings
- Includes API settings and a danger zone section for workspace owners
- Uses Supabase client for fetching user and workspace data

### Workspace Content Updates
- Added dynamic import of `SettingsContent` with loading skeleton
- Extended `WorkspaceContent` to support `settings` as a view mode
- Implemented navigation method `navigateToSettings` to switch views and update URL
- Updated UI to render Settings content with transition effects

## Test plan
- [x] Navigate to Settings from sidebar and mobile navigation
- [x] Verify Settings page loads with workspace settings data
- [x] Confirm only workspace owners see the Danger Zone section
- [x] Check URL updates correctly when navigating to Settings
- [x] Ensure smooth transitions between views including Settings
- [x] Validate no regressions in existing navigation flows (Issues, Inbox, Cookbook)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4a84587c-0a14-4573-a75b-a391c8c78f6c