### PR TITLE
Fix workspace creation error with RPC function

### DIFF
--- a/test/utils/mock-factory.ts
+++ b/test/utils/mock-factory.ts
@@ -59,6 +59,7 @@ export const createMockSupabaseClient = (overrides: any = {}) => {
   return {
     auth: mockAuth,
     from: mockFrom,
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Fixed critical bug where users were unable to create workspaces (100% failure rate)
- Replaced direct Supabase table inserts with atomic RPC function
- Resolved Row Level Security (RLS) policy evaluation issues

## Root Cause
The issue was caused by RLS policy evaluation problems when inserting directly into the workspaces table from the client. The workspace creation required simultaneous creation of:
1. A workspace record in the `workspaces` table
2. A membership record in the `workspace_members` table

This created a chicken-and-egg problem where:
- The workspace INSERT policy required `auth.uid() = owner_id`
- The workspace_members INSERT policy required the user to already be an owner/admin
- Client-side inserts were failing with 406/403 errors before even reaching RLS

## Solution
Created a SECURITY DEFINER RPC function `create_workspace` that:
- Bypasses RLS evaluation issues
- Handles workspace and membership creation atomically in a single transaction
- Validates user authentication server-side
- Checks for duplicate slugs before insertion
- Returns detailed error information

## Changes Made
1. **Database Migration**: Added `create_workspace` RPC function
2. **Component Updates**: 
   - Updated `CreateWorkspaceForm.tsx` to use RPC function
   - Updated `create-workspace-modal.tsx` to use RPC function
   - Added comprehensive error handling
3. **Test Updates**:
   - Fixed mock factory to include `rpc` method
   - Updated all test expectations to use RPC instead of direct inserts

## Test Plan
- [x] All 470 tests passing locally
- [x] Pre-commit hooks passed
- [x] Pre-push checks passed (type checking and build)
- [ ] Verify Vercel CI passes
- [ ] Manual testing of workspace creation flow

🤖 Generated with [Claude Code](https://claude.ai/code)