### PR TITLE
Add issue types sidebar with collapsible navigation and filtered issue views

### DIFF
--- a/app/[slug]/issues/[type]/page.tsx
+++ b/app/[slug]/issues/[type]/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { use } from 'react'
+import { notFound } from 'next/navigation'
+import { WorkspaceWithMobileNav } from '@/components/layout/workspace-with-mobile-nav'
+import { WorkspaceContent, WorkspaceContentRef } from '@/components/workspace/workspace-content'
+import { useWorkspace } from '@/contexts/workspace-context'
+import { IssueType } from '@/lib/validation/issue-validation'
+
+const VALID_ISSUE_TYPES = ['features', 'bugs', 'design', 'non-technical'] as const
+
+type ValidIssueType = typeof VALID_ISSUE_TYPES[number]
+
+const typeMapping: Record<ValidIssueType, IssueType> = {
+  'features': 'feature',
+  'bugs': 'bug',
+  'design': 'design',
+  'non-technical': 'non-technical'
+}
+
+export default function IssueTypePage({ 
+  params 
+}: { 
+  params: Promise<{ slug: string; type: string }> 
+}) {
+  const resolvedParams = use(params)
+  const { workspace } = useWorkspace()
+  const contentRef = useRef<WorkspaceContentRef>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  // Validate the issue type
+  if (!VALID_ISSUE_TYPES.includes(resolvedParams.type as ValidIssueType)) {
+    notFound()
+  }
+
+  const issueType = typeMapping[resolvedParams.type as ValidIssueType]
+
+  const handleIssueCreated = () => {
+    setRefreshKey(prev => prev + 1)
+  }
+
+  const handleNavigateToIssues = () => {
+    contentRef.current?.navigateToIssuesList()
+  }
+
+  const handleNavigateToInbox = () => {
+    contentRef.current?.navigateToInbox()
+  }
+
+  const handleNavigateToCookbook = () => {
+    contentRef.current?.navigateToCookbook()
+  }
+
+  if (!workspace) return null
+
+  return (
+    <WorkspaceWithMobileNav 
+      workspace={workspace} 
+      onIssueCreated={handleIssueCreated}
+      onNavigateToIssues={handleNavigateToIssues}
+      onNavigateToInbox={handleNavigateToInbox}
+      onNavigateToCookbook={handleNavigateToCookbook}
+    >
+      <WorkspaceContent 
+        ref={contentRef}
+        key={refreshKey} 
+        workspace={workspace}
+        initialTypeFilter={issueType}
+      />
+    </WorkspaceWithMobileNav>
+  )
+}

--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Plus, ChevronLeft, ChevronRight, HelpCircle, Settings, Terminal, BookOpen, Search } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, HelpCircle, Settings, Terminal, BookOpen, Search, ChevronDown, Bug, Sparkles, Palette, MessageSquare } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { UserWorkspace } from '@/lib/supabase/workspaces'
 import { subscribeToCreateIssueRequests, emitToggleSearch } from '@/lib/events/issue-events'
@@ -60,6 +60,7 @@ export function WorkspaceLayout({
   const [localIsMobileMenuOpen, setLocalIsMobileMenuOpen] = useState(false)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
   const [isSidebarHovered, setIsSidebarHovered] = useState(false)
+  const [isIssuesExpanded, setIsIssuesExpanded] = useState(true)
   const pathname = usePathname()
   const { openWithMode } = useCommandPalette()
   const localSidebarRef = useRef<HTMLDivElement>(null)
@@ -177,37 +178,93 @@ export function WorkspaceLayout({
         )}
         */}
         
-        {onNavigateToIssues ? (
+        {/* Issues Section with Collapsible Sub-items */}
+        <div className="mt-1">
           <button
             data-sidebar-item
-            onClick={onNavigateToIssues}
-            className={`w-full flex items-center space-x-2 md:space-x-3 px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors mt-1 focus:outline-none ${
-              pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issue/`)
+            onClick={() => {
+              if (pathname === `/${workspace.slug}` || pathname === `/${workspace.slug}/issues/all`) {
+                // If already on main issues page, just toggle expansion
+                setIsIssuesExpanded(!isIssuesExpanded)
+              } else {
+                // Navigate to main issues page and expand
+                setIsIssuesExpanded(true)
+                if (onNavigateToIssues) {
+                  onNavigateToIssues()
+                }
+              }
+            }}
+            className={`w-full flex items-center justify-between px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors focus:outline-none ${
+              pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issues/`) || pathname.startsWith(`/${workspace.slug}/issue/`)
                 ? 'bg-accent text-foreground' 
                 : 'hover:bg-accent text-foreground'
             }`}
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <span>Issues</span>
+            <div className="flex items-center space-x-2 md:space-x-3">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>Issues</span>
+            </div>
+            <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${
+              isIssuesExpanded ? 'rotate-180' : ''
+            }`} />
           </button>
-        ) : (
-          <Link
-            data-sidebar-item
-            href={`/${workspace.slug}`}
-            className={`flex items-center space-x-2 md:space-x-3 px-3 md:px-3 min-h-[44px] md:min-h-0 md:py-2 rounded-lg transition-colors mt-1 focus:outline-none ${
-              pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issue/`)
-                ? 'bg-accent text-foreground' 
-                : 'hover:bg-accent text-foreground'
-            }`}
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <span>Issues</span>
-          </Link>
-        )}
+          
+          {/* Issue Type Sub-navigation */}
+          {isIssuesExpanded && (
+            <div className="ml-7 mt-1 space-y-0.5">
+              <Link
+                data-sidebar-item
+                href={`/${workspace.slug}/issues/features`}
+                className={`flex items-center space-x-2 px-3 py-1.5 rounded-md transition-colors text-sm focus:outline-none ${
+                  pathname === `/${workspace.slug}/issues/features`
+                    ? 'bg-accent text-foreground' 
+                    : 'hover:bg-accent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <Sparkles className="w-4 h-4" />
+                <span>Features</span>
+              </Link>
+              <Link
+                data-sidebar-item
+                href={`/${workspace.slug}/issues/bugs`}
+                className={`flex items-center space-x-2 px-3 py-1.5 rounded-md transition-colors text-sm focus:outline-none ${
+                  pathname === `/${workspace.slug}/issues/bugs`
+                    ? 'bg-accent text-foreground' 
+                    : 'hover:bg-accent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <Bug className="w-4 h-4" />
+                <span>Bugs</span>
+              </Link>
+              <Link
+                data-sidebar-item
+                href={`/${workspace.slug}/issues/design`}
+                className={`flex items-center space-x-2 px-3 py-1.5 rounded-md transition-colors text-sm focus:outline-none ${
+                  pathname === `/${workspace.slug}/issues/design`
+                    ? 'bg-accent text-foreground' 
+                    : 'hover:bg-accent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <Palette className="w-4 h-4" />
+                <span>Design</span>
+              </Link>
+              <Link
+                data-sidebar-item
+                href={`/${workspace.slug}/issues/non-technical`}
+                className={`flex items-center space-x-2 px-3 py-1.5 rounded-md transition-colors text-sm focus:outline-none ${
+                  pathname === `/${workspace.slug}/issues/non-technical`
+                    ? 'bg-accent text-foreground' 
+                    : 'hover:bg-accent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <MessageSquare className="w-4 h-4" />
+                <span>Non-technical</span>
+              </Link>
+            </div>
+          )}
+        </div>
         
         {/* Cookbook */}
         {onNavigateToCookbook ? (
@@ -354,10 +411,11 @@ export function WorkspaceLayout({
                 <button
                   onClick={onNavigateToIssues}
                   className={`p-2 rounded mb-2 transition-colors ${
-                    pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issue/`)
+                    pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issues/`) || pathname.startsWith(`/${workspace.slug}/issue/`)
                       ? 'bg-accent' 
                       : 'hover:bg-accent'
                   }`}
+                  title="Issues"
                 >
                   <svg className="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -367,10 +425,11 @@ export function WorkspaceLayout({
                 <Link
                   href={`/${workspace.slug}`}
                   className={`p-2 rounded mb-2 transition-colors ${
-                    pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issue/`)
+                    pathname === `/${workspace.slug}` || pathname.startsWith(`/${workspace.slug}/issues/`) || pathname.startsWith(`/${workspace.slug}/issue/`)
                       ? 'bg-accent' 
                       : 'hover:bg-accent'
                   }`}
+                  title="Issues"
                 >
                   <svg className="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -86,6 +86,7 @@ interface WorkspaceContentProps {
   }
   initialView?: 'list' | 'issue' | 'inbox' | 'cookbook' | 'recipe'
   initialIssueId?: string
+  initialTypeFilter?: string
 }
 
 export interface WorkspaceContentRef {
@@ -139,7 +140,7 @@ const sortOptions = [
 ]
 
 export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContentProps>(
-  function WorkspaceContent({ workspace, initialView = 'list', initialIssueId }, ref) {
+  function WorkspaceContent({ workspace, initialView = 'list', initialIssueId, initialTypeFilter }, ref) {
   const pathname = usePathname()
   
   // Extract issue ID from URL if present
@@ -174,7 +175,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   // List view defaults to Active (exclude_done), Kanban defaults to All
   const [statusFilter, setStatusFilter] = useState<string>('exclude_done')
   const [priorityFilter, setPriorityFilter] = useState<string>('all')
-  const [typeFilter, setTypeFilter] = useState<string>('all')
+  const [typeFilter, setTypeFilter] = useState<string>(initialTypeFilter || 'all')
   const [tagFilter, setTagFilter] = useState<string>('all')
   const [sortBy, setSortBy] = useState<string>('newest')
   const [searchQuery, setSearchQuery] = useState<string>('')


### PR DESCRIPTION
## Summary
- Introduces a new sidebar section for issue types with collapsible sub-navigation
- Adds dedicated pages for filtering issues by type (features, bugs, design, non-technical)
- Updates workspace content to support initial filtering by issue type
- Enhances sidebar UI with icons and expand/collapse toggle for better navigation

## Changes

### New Feature Pages
- Created `app/[slug]/issues/[type]/page.tsx` to render issues filtered by type
- Validates issue types and updates workspace content accordingly

### Sidebar Layout
- Modified `WorkspaceLayout` to include an expandable "Issues" section
- Added sub-links for each issue type with corresponding icons
- Implemented toggle button to expand/collapse issue type links
- Updated active link highlighting to support new issue type routes

### Workspace Content
- Extended `WorkspaceContent` component to accept `initialTypeFilter` prop
- Initialized issue type filter state based on the current route

## Test plan
- [x] Navigate to main issues page and toggle issue types sidebar
- [x] Click on each issue type link and verify filtered issues display
- [x] Confirm sidebar highlights active issue type correctly
- [x] Ensure workspace content updates filter on navigation
- [x] Validate that invalid issue types show 404 not found
- [x] Test expand/collapse behavior of issues sidebar section

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/aa580a7c-131b-40fc-b599-aa2eecd99d2a