### PR TITLE
fix(navigation): fix All Issues sidebar link not working from other pages

### DIFF
--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -312,11 +312,22 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   }
 
   const handleBackToList = useCallback(() => {
-    setCurrentView('list')
-    setCurrentIssueId(null)
-    setCurrentRecipeId(null)
-    // Update URL without page refresh
-    window.history.pushState({}, '', `/${workspace.slug}`)
+    // If we're on a different page route (sprint-board, design, product), 
+    // we need to actually navigate, not just update the view
+    const currentPath = window.location.pathname
+    if (currentPath.includes('/sprint-board') || 
+        currentPath.includes('/design') || 
+        currentPath.includes('/product')) {
+      // Use actual navigation to go to the main workspace page
+      window.location.href = `/${workspace.slug}`
+    } else {
+      // Otherwise, just update the view state
+      setCurrentView('list')
+      setCurrentIssueId(null)
+      setCurrentRecipeId(null)
+      // Update URL without page refresh
+      window.history.pushState({}, '', `/${workspace.slug}`)
+    }
   }, [workspace.slug])
 
   const handleBackToCookbook = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixed issue where clicking "All Issues" from sprint-board, design, or product pages wouldn't navigate to the main workspace page
- The app now performs a full page navigation instead of just updating the view state when navigating from these specific routes

## Test plan
- [x] Navigate to /sprint-board, /design, or /product pages
- [x] Click "All Issues" in the sidebar
- [x] Verify user is redirected to the main workspace page showing the issue list
- [x] Verify navigation still works correctly when already on the main workspace page
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)