### PR TITLE
fix(filters): reset all filters when clicking 'All Issues' in sidebar

### DIFF
--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -166,7 +166,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
   // List view defaults to Active (exclude_done), Kanban defaults to All
   const [statusFilter, setStatusFilter] = useState<string>('exclude_done')
   const [priorityFilter, setPriorityFilter] = useState<string>('all')
-  const [typeFilter] = useState<string>(presetTypeFilter || 'all')
+  const [typeFilter, setTypeFilter] = useState<string>(presetTypeFilter || 'all')
   const [tagFilter, setTagFilter] = useState<string>('all')
   const [sortBy, setSortBy] = useState<string>('newest')
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -315,6 +315,10 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
     setCurrentView('list')
     setCurrentIssueId(null)
     setCurrentRecipeId(null)
+    // Reset filters to show all active issues
+    setTypeFilter('all')
+    setPriorityFilter('all')
+    setStatusFilter('exclude_done')
     // Update URL without page refresh
     window.history.pushState({}, '', `/${workspace.slug}`)
   }, [workspace.slug])


### PR DESCRIPTION
## Summary
This PR fixes a bug where type filters persist when navigating from filtered pages (Design, Sprint Board, Product) back to "All Issues" via the sidebar.

## Problem
When a user:
1. Clicks "Design" in the sidebar (which shows only design-type issues)
2. Then clicks "All Issues" in the sidebar
3. The type filter remains set to "design", so they still only see design issues instead of all active issues

## Solution
- Made `typeFilter` mutable by adding `setTypeFilter` to the useState hook
- Updated `handleBackToList` to reset all filters to their default values:
  - `typeFilter` → 'all'
  - `priorityFilter` → 'all'
  - `statusFilter` → 'exclude_done'

This ensures that clicking "All Issues" always shows all active issues regardless of any previously applied filters.

## Test Plan
1. Navigate to a workspace
2. Click "Design" in the sidebar - verify you only see design-type issues
3. Click "All Issues" in the sidebar - verify you now see all active issues (not just design)
4. Repeat test with Sprint Board and Product pages

🤖 Generated with [Claude Code](https://claude.ai/code)