### PR TITLE
Fix stale closure issue in cache size update

### DIFF
--- a/contexts/issue-cache-context.tsx
+++ b/contexts/issue-cache-context.tsx
@@ -278,9 +278,8 @@ export function IssueCacheProvider({ children }: { children: ReactNode }) {
       storeIssues(issuesToStore)
     }
     
-    // Capture size before setState to avoid stale closure
-    const newCacheSize = cache.size + issuesToStore.length
-    setCacheStats(prev => ({ ...prev, size: newCacheSize }))
+    // Update cache size using previous state to avoid stale closure
+    setCacheStats(prev => ({ ...prev, size: prev.size + issuesToStore.length }))
   }, [cache])
 
   const invalidateListCache = useCallback((workspaceId: string) => {


### PR DESCRIPTION
## Summary
- Fixes a stale closure issue when updating cache size in `IssueCacheProvider`
- Ensures cache size is updated based on previous state instead of current closure value

## Changes

### IssueCacheProvider Context
- Updated `setCacheStats` call to use functional update with previous state (`prev`) to correctly increment cache size
- Removed direct calculation of new cache size from `cache.size` to avoid stale closure

## Test plan
- [ ] Verify that cache size updates correctly when new issues are stored
- [ ] Confirm no stale closure warnings or incorrect cache size values occur
- [ ] Test related cache invalidation and storage logic to ensure stability

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9b02e643-47a2-45f2-a9be-790a9d36342c