### PR TITLE
Fix onboarding redirect loops and profile fetching errors

### DIFF
--- a/app/CreateUser/page.tsx
+++ b/app/CreateUser/page.tsx
@@ -11,11 +11,16 @@ export default async function CreateUserPage() {
   }
 
   // Check if user already has a profile
-  const { data: existingUser } = await supabase
+  const { data: existingUser, error } = await supabase
     .from('users')
     .select('id')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
+
+  // If there's an error fetching the profile, log it but continue
+  if (error) {
+    console.error('Error checking existing user profile:', error)
+  }
 
   if (existingUser) {
     redirect('/CreateWorkspace')

--- a/app/CreateWorkspace/page.tsx
+++ b/app/CreateWorkspace/page.tsx
@@ -16,7 +16,7 @@ export default async function CreateWorkspacePage() {
     .from('users')
     .select('id')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
 
   if (!userProfile) {
     redirect('/CreateUser')

--- a/app/api/generate-prompt/route.ts
+++ b/app/api/generate-prompt/route.ts
@@ -105,7 +105,7 @@ async function handlePOST(req: NextRequest) {
       .from('users')
       .select('id')
       .eq('id', user.id)
-      .single()
+      .maybeSingle()
 
     if (!userProfile) {
       return NextResponse.json({ error: 'User profile not found' }, { status: 404 })

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -23,7 +23,7 @@ export default async function SuccessPage({
     .from('users')
     .select('name, avatar_url')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
 
   if (!profile) {
     redirect('/CreateUser')

--- a/app/user/settings/page.tsx
+++ b/app/user/settings/page.tsx
@@ -25,7 +25,7 @@ export default async function UserSettingsPage() {
     .from('users')
     .select('id, name, avatar_url')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
   
   if (!profile) {
     redirect('/CreateUser')

--- a/app/workspace-deleted/page.tsx
+++ b/app/workspace-deleted/page.tsx
@@ -21,7 +21,7 @@ export default async function WorkspaceDeletedPage() {
     .from('users')
     .select('name, avatar_url')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
 
   if (!profile) {
     redirect('/CreateUser')

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -15,7 +15,7 @@ export default async function WorkspaceLoadingPage() {
     .from('users')
     .select('id')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
 
   if (!profile) {
     redirect('/CreateUser')

--- a/components/auth/CreateUserForm.tsx
+++ b/components/auth/CreateUserForm.tsx
@@ -41,9 +41,6 @@ export default function CreateUserForm() {
         throw insertError
       }
 
-      // Add a small delay to ensure the profile is properly created
-      await new Promise(resolve => setTimeout(resolve, 500))
-
       // Invalidate middleware cache for this user
       if (typeof window !== 'undefined') {
         try {
@@ -57,8 +54,9 @@ export default function CreateUserForm() {
         }
       }
 
-      // Use window.location for a hard refresh to ensure server-side cache is cleared
-      window.location.href = '/CreateWorkspace'
+      // Refresh the router to get the latest data and then navigate
+      await router.refresh()
+      router.push('/CreateWorkspace')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     } finally {

--- a/components/auth/CreateUserForm.tsx
+++ b/components/auth/CreateUserForm.tsx
@@ -41,6 +41,9 @@ export default function CreateUserForm() {
         throw insertError
       }
 
+      // Add a small delay to ensure the profile is properly created
+      await new Promise(resolve => setTimeout(resolve, 500))
+
       // Invalidate middleware cache for this user
       if (typeof window !== 'undefined') {
         try {
@@ -54,7 +57,8 @@ export default function CreateUserForm() {
         }
       }
 
-      router.push('/CreateWorkspace')
+      // Use window.location for a hard refresh to ensure server-side cache is cleared
+      window.location.href = '/CreateWorkspace'
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     } finally {

--- a/components/settings/profile-settings.tsx
+++ b/components/settings/profile-settings.tsx
@@ -50,7 +50,7 @@ export function ProfileSettings({ onAvatarUpdate }: ProfileSettingsProps) {
           .from('users')
           .select('name, avatar_url')
           .eq('id', user.id)
-          .single()
+          .maybeSingle()
 
         if (error) throw error
 

--- a/contexts/profile-context.tsx
+++ b/contexts/profile-context.tsx
@@ -50,11 +50,8 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
       const supabase = createClient()
       const { data: { user }, error: authError } = await supabase.auth.getUser()
       
-      if (authError) {
-        throw new Error(`Authentication failed: ${authError.message}`)
-      }
-      
-      if (!user) {
+      if (authError || !user) {
+        // User is not authenticated, which is fine for public pages
         setProfile(null)
         return
       }
@@ -63,7 +60,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         .from('users')
         .select('id, name, avatar_url')
         .eq('id', user.id)
-        .single()
+        .maybeSingle()
       
       if (profileError) {
         throw new Error(`Failed to fetch profile: ${profileError.message}`)

--- a/middleware.ts
+++ b/middleware.ts
@@ -224,7 +224,7 @@ export async function middleware(request: NextRequest) {
             .from('users')
             .select('id')
             .eq('id', user.id)
-            .single(),
+            .maybeSingle(),
           supabase
             .from('workspace_members')
             .select('workspace_id')

--- a/test/__tests__/components/auth/CreateUserForm.test.tsx
+++ b/test/__tests__/components/auth/CreateUserForm.test.tsx
@@ -21,6 +21,10 @@ describe('CreateUserForm', () => {
     ;(createClient as any).mockReturnValue(mockSupabase)
     ;(useRouter as any).mockReturnValue(mockRouter)
     
+    // Mock window.location.href
+    delete (window as any).location
+    window.location = { href: '' } as any
+    
     // Default to authenticated user
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: mockUser },
@@ -163,7 +167,7 @@ describe('CreateUserForm', () => {
           name: 'Test User',
           avatar_url: '🐱',
         })
-        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
+        expect(window.location.href).toBe('/CreateWorkspace')
       })
     })
 
@@ -301,7 +305,7 @@ describe('CreateUserForm', () => {
       
       await waitFor(() => {
         expect(screen.queryByText('First error')).not.toBeInTheDocument()
-        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
+        expect(window.location.href).toBe('/CreateWorkspace')
       })
     })
   })

--- a/test/__tests__/components/auth/CreateUserForm.test.tsx
+++ b/test/__tests__/components/auth/CreateUserForm.test.tsx
@@ -21,10 +21,6 @@ describe('CreateUserForm', () => {
     ;(createClient as any).mockReturnValue(mockSupabase)
     ;(useRouter as any).mockReturnValue(mockRouter)
     
-    // Mock window.location.href
-    delete (window as any).location
-    window.location = { href: '' } as any
-    
     // Default to authenticated user
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: mockUser },
@@ -167,7 +163,8 @@ describe('CreateUserForm', () => {
           name: 'Test User',
           avatar_url: '🐱',
         })
-        expect(window.location.href).toBe('/CreateWorkspace')
+        expect(mockRouter.refresh).toHaveBeenCalled()
+        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
       })
     })
 
@@ -305,7 +302,8 @@ describe('CreateUserForm', () => {
       
       await waitFor(() => {
         expect(screen.queryByText('First error')).not.toBeInTheDocument()
-        expect(window.location.href).toBe('/CreateWorkspace')
+        expect(mockRouter.refresh).toHaveBeenCalled()
+        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
       })
     })
   })

--- a/test/__tests__/middleware.test.ts
+++ b/test/__tests__/middleware.test.ts
@@ -62,7 +62,7 @@ describe('middleware', () => {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         limit: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
       })),
     }
     
@@ -194,7 +194,7 @@ describe('middleware', () => {
               select: vi.fn().mockReturnThis(),
               eq: vi.fn().mockReturnThis(),
               limit: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ 
+              maybeSingle: vi.fn().mockResolvedValue({ 
                 data: null, // No profile
                 error: null 
               }),
@@ -272,7 +272,7 @@ describe('middleware', () => {
               select: vi.fn().mockReturnThis(),
               eq: vi.fn().mockReturnThis(),
               limit: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ 
+              maybeSingle: vi.fn().mockResolvedValue({ 
                 data: table === 'users' ? { id: mockUser.id } : null, 
                 error: null 
               }),
@@ -340,7 +340,7 @@ describe('middleware', () => {
               select: vi.fn().mockReturnThis(),
               eq: vi.fn().mockReturnThis(),
               limit: vi.fn().mockReturnThis(),
-              single: vi.fn().mockResolvedValue({ 
+              maybeSingle: vi.fn().mockResolvedValue({ 
                 data: table === 'users' ? { id: mockUser.id } : null, 
                 error: null 
               }),


### PR DESCRIPTION
## Summary
- Fixes blank screen issue during user onboarding process
- Resolves infinite redirect loop between CreateUser and CreateWorkspace pages
- Fixes 406 errors when fetching user profiles

## Changes Made
1. **Profile Query Updates**: Replaced `.single()` with `.maybeSingle()` in all user profile queries to handle cases where profiles don't exist yet
2. **CreateUserForm Redirect**: Changed from `router.push()` to `window.location.href` for hard refresh after profile creation to ensure server-side cache is cleared
3. **Profile Context**: Updated to handle unauthenticated users gracefully on public pages
4. **Test Fixes**: Updated middleware tests and CreateUserForm tests to match the new implementation

## Test Plan
- [x] All tests pass locally (`npm test`)
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass (type checking and build)
- [ ] Manual testing of onboarding flow
- [ ] Verify no redirect loops occur
- [ ] Verify profile creation works correctly

## Related Issues
Fixes the onboarding issues reported where users see a blank screen after creating their profile.

🤖 Generated with [Claude Code](https://claude.ai/code)