### PR TITLE
fix: ensure workspace creation always redirects properly

### DIFF
--- a/test/__tests__/components/auth/CreateWorkspaceForm.test.tsx
+++ b/test/__tests__/components/auth/CreateWorkspaceForm.test.tsx
@@ -272,7 +272,7 @@ describe('CreateWorkspaceForm', () => {
           p_slug: 'test-workspace',
           p_avatar_url: '🚀'
         })
-        expect(mockRouter.push).toHaveBeenCalledWith('/success')
+        expect(mockRouter.replace).toHaveBeenCalledWith('/success')
       })
     })
 
@@ -332,9 +332,9 @@ describe('CreateWorkspaceForm', () => {
         expect(screen.getByLabelText('Workspace URL (Required)')).toHaveValue('test-workspace')
       })
       
-      // Simulate Cmd+Enter on the container
-      const container = screen.getByText('Create Your Workspace').closest('div')!
-      fireEvent.keyDown(container, {
+      // Simulate Cmd+Enter on the form
+      const form = screen.getByText('Create Your Workspace').closest('form')!
+      fireEvent.keyDown(form, {
         key: 'Enter',
         metaKey: true,
       })


### PR DESCRIPTION
- Convert to form element with proper submit handling
- Add preventDefault to avoid page refresh
- Use router.replace instead of push to prevent back button issues
- Add multiple fallback redirect strategies
- Ensure redirect happens even if other operations fail

This prevents the page refresh loop where users get stuck on CreateWorkspace after successfully creating a workspace.

🤖 Generated with [Claude Code](https://claude.ai/code)