### PR TITLE
fix: restore hard refresh for CreateUser redirect

### DIFF
--- a/components/auth/CreateUserForm.tsx
+++ b/components/auth/CreateUserForm.tsx
@@ -17,7 +17,8 @@ export default function CreateUserForm() {
   const router = useRouter()
   const supabase = createClient()
 
-  const handleSave = async () => {
+  const handleSave = async (e?: React.FormEvent) => {
+    e?.preventDefault()
     setIsLoading(true)
     setError(null)
 
@@ -54,9 +55,14 @@ export default function CreateUserForm() {
         }
       }
 
-      // Refresh the router to get the latest data and then navigate
-      await router.refresh()
-      router.push('/CreateWorkspace')
+      // Use window.location for a hard refresh to ensure server-side cache is cleared
+      // This prevents the blank screen issue when the server component revalidates
+      if (typeof window !== 'undefined') {
+        window.location.href = '/CreateWorkspace'
+      } else {
+        // Fallback for SSR (shouldn't happen in client component)
+        router.push('/CreateWorkspace')
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     } finally {
@@ -74,7 +80,10 @@ export default function CreateUserForm() {
   }
 
   return (
-    <div className="bg-card p-4 md:p-6 lg:p-8 rounded-lg shadow-lg max-w-md w-full" onKeyDown={handleKeyDown}>
+    <form 
+      onSubmit={handleSave}
+      className="bg-card p-4 md:p-6 lg:p-8 rounded-lg shadow-lg max-w-md w-full" 
+      onKeyDown={handleKeyDown}>
       <h1 className="text-2xl font-bold text-center mb-8">Complete Your Profile</h1>
       
       <div className="mb-4 md:mb-6">
@@ -131,7 +140,7 @@ export default function CreateUserForm() {
       )}
 
       <button
-        onClick={handleSave}
+        type="submit"
         disabled={!isValidName || isLoading}
         className={`w-full py-2 px-4 md:py-2.5 md:px-5 rounded-lg font-medium transition-all ${
           isValidName && !isLoading
@@ -141,6 +150,6 @@ export default function CreateUserForm() {
       >
         {isLoading ? 'Saving...' : 'Save'}
       </button>
-    </div>
+    </form>
   )
 }

--- a/test/__tests__/components/auth/CreateUserForm.test.tsx
+++ b/test/__tests__/components/auth/CreateUserForm.test.tsx
@@ -21,6 +21,10 @@ describe('CreateUserForm', () => {
     ;(createClient as any).mockReturnValue(mockSupabase)
     ;(useRouter as any).mockReturnValue(mockRouter)
     
+    // Mock window.location.href
+    delete (window as any).location
+    window.location = { href: '' } as any
+    
     // Default to authenticated user
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: mockUser },
@@ -163,8 +167,7 @@ describe('CreateUserForm', () => {
           name: 'Test User',
           avatar_url: '🐱',
         })
-        expect(mockRouter.refresh).toHaveBeenCalled()
-        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
+        expect(window.location.href).toBe('/CreateWorkspace')
       })
     })
 
@@ -202,9 +205,9 @@ describe('CreateUserForm', () => {
       const nameInput = screen.getByLabelText('Your Name (Required)')
       await user.type(nameInput, 'Test User')
       
-      // Simulate Cmd+Enter on the container
-      const container = screen.getByText('Complete Your Profile').closest('div')!
-      fireEvent.keyDown(container, {
+      // Simulate Cmd+Enter on the form
+      const form = screen.getByText('Complete Your Profile').closest('form')!
+      fireEvent.keyDown(form, {
         key: 'Enter',
         metaKey: true,
       })
@@ -302,8 +305,7 @@ describe('CreateUserForm', () => {
       
       await waitFor(() => {
         expect(screen.queryByText('First error')).not.toBeInTheDocument()
-        expect(mockRouter.refresh).toHaveBeenCalled()
-        expect(mockRouter.push).toHaveBeenCalledWith('/CreateWorkspace')
+        expect(window.location.href).toBe('/CreateWorkspace')
       })
     })
   })


### PR DESCRIPTION
- Use window.location.href instead of router.push to prevent blank screen
- This ensures server-side cache is cleared after profile creation
- Wrap form in proper form element with submit handling
- Update tests to mock window.location properly

This fixes the recurring issue where users see a blank CreateUser page after successfully creating their profile.

🤖 Generated with [Claude Code](https://claude.ai/code)