### PR TITLE
Fix: Enable AI prompt generation with centralized API keys

### DIFF
--- a/app/api/workspace/has-api-key/route.ts
+++ b/app/api/workspace/has-api-key/route.ts
@@ -52,9 +52,15 @@ async function handlePOST(req: NextRequest) {
       )
     }
 
-    // Return whether the workspace has an API key configured
+    // Check for centralized API key in environment variables
+    const hasCentralizedKey = !!(
+      process.env['CENTRALIZED_OPENAI_API_KEY'] || 
+      process.env['CENTRALIZED_ANTHROPIC_API_KEY']
+    )
+    
+    // Return whether the workspace has an API key configured (either workspace-specific or centralized)
     return NextResponse.json({ 
-      hasApiKey: !!workspace.api_key 
+      hasApiKey: !!workspace.api_key || hasCentralizedKey
     })
 
   } catch (error) {

--- a/app/api/workspace/has-centralized-key/route.ts
+++ b/app/api/workspace/has-centralized-key/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  // Check for centralized API keys in environment variables
+  const hasCentralizedKey = !!(
+    process.env['CENTRALIZED_OPENAI_API_KEY'] || 
+    process.env['CENTRALIZED_ANTHROPIC_API_KEY']
+  )
+  
+  return NextResponse.json({ 
+    hasCentralizedKey 
+  })
+}

--- a/supabase/migrations/20250124_add_missing_api_columns.sql
+++ b/supabase/migrations/20250124_add_missing_api_columns.sql
@@ -1,0 +1,10 @@
+-- Add missing api_key and api_provider columns to workspaces table
+-- These were referenced in 20240117_add_llm_fields.sql but not actually created in the initial schema
+
+ALTER TABLE public.workspaces 
+ADD COLUMN IF NOT EXISTS api_key TEXT,
+ADD COLUMN IF NOT EXISTS api_provider TEXT;
+
+-- Add comments for documentation
+COMMENT ON COLUMN public.workspaces.api_key IS 'Encrypted API key for LLM provider';
+COMMENT ON COLUMN public.workspaces.api_provider IS 'LLM provider (openai, anthropic, etc)';

--- a/test/__tests__/components/issues/edit-issue-modal.test.tsx
+++ b/test/__tests__/components/issues/edit-issue-modal.test.tsx
@@ -117,12 +117,20 @@ describe('EditIssueModal - Prompt Generation', () => {
     vi.clearAllMocks()
     
     // Mock fetch API
-    global.fetch = vi.fn(() => 
-      Promise.resolve({
+    global.fetch = vi.fn((url) => {
+      // Mock the centralized key check endpoint
+      if (url && url.includes('/api/workspace/has-centralized-key')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hasCentralizedKey: false })
+        } as Response)
+      }
+      // Default response for other endpoints
+      return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ success: true })
       } as Response)
-    )
+    })
     
     // Reset the mock implementation but preserve the tag-related functionality
     mockSupabase.from.mockImplementation((table: any) => {
@@ -156,7 +164,13 @@ describe('EditIssueModal - Prompt Generation', () => {
             const chainableQuery = {
               eq: vi.fn(() => chainableQuery),
               single: vi.fn(() => Promise.resolve({ 
-                data: { id: 'test-workspace-id', name: 'Test Workspace', api_key: 'test-key', api_provider: 'openai' }, 
+                data: { 
+                  id: 'test-workspace-id', 
+                  name: 'Test Workspace', 
+                  api_key: 'test-key', 
+                  api_provider: 'openai',
+                  workspace_members: [{ user_id: 'test-user-id', role: 'owner' }]
+                }, 
                 error: null 
               }))
             }


### PR DESCRIPTION
## Summary
- Fixes bug where new workspaces couldn't generate AI prompts even when centralized API keys were configured
- Adds support for centralized API key detection in the frontend
- Includes database migration to add missing columns

## Problem
When creating a new workspace, the "Create a prompt" toggle was disabled even though the backend supported centralized API keys via environment variables (`CENTRALIZED_OPENAI_API_KEY`). This prevented users from using AI features without manually configuring API keys for each workspace.

## Solution
1. Updated the workspace context to check for centralized API keys
2. Added new endpoint `/api/workspace/has-centralized-key` to detect centralized keys
3. Modified the existing has-api-key endpoint to consider both workspace and centralized keys
4. Added migration to fix missing `api_key` and `api_provider` columns in the workspaces table
5. Updated tests to properly mock the centralized key checks

## Test plan
- [x] Run `npm test` - all tests pass
- [x] Run `npm run type-check` - no errors
- [x] Run `npm run lint` - no errors
- [x] Pre-push hooks pass
- [ ] Set `CENTRALIZED_OPENAI_API_KEY` in `.env.local`
- [ ] Create a new workspace
- [ ] Verify "Create a prompt" toggle is enabled
- [ ] Create an issue with prompt generation enabled
- [ ] Verify AI prompt is generated successfully

🤖 Generated with [Claude Code](https://claude.ai/code)