### PR TITLE
fix: redirect authenticated users from root to their workspace

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 import { EmailLogin } from '@/components/auth/email-login'
 import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserWorkspaces } from '@/lib/supabase/workspaces'
 
 export default async function Home(props: {
   searchParams: Promise<{ code?: string }>
@@ -9,6 +11,39 @@ export default async function Home(props: {
   // If there's an auth code in the URL, redirect to the callback route
   if (searchParams.code) {
     redirect(`/auth/callback?code=${searchParams.code}`)
+  }
+  
+  // Check if user is authenticated
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  
+  if (user) {
+    // Check if user has a profile
+    const { data: profile } = await supabase
+      .from('users')
+      .select('id')
+      .eq('id', user.id)
+      .single()
+    
+    if (!profile) {
+      redirect('/CreateUser')
+    }
+    
+    // Check if user has workspaces
+    const workspaces = await getUserWorkspaces()
+    
+    if (!workspaces || workspaces.length === 0) {
+      redirect('/CreateWorkspace')
+    }
+    
+    // Redirect to first workspace (we know workspaces[0] exists from the check above)
+    const firstWorkspace = workspaces[0]
+    if (firstWorkspace) {
+      redirect(`/${firstWorkspace.slug}`)
+    }
+    
+    // Fallback to CreateWorkspace if somehow no workspace exists
+    redirect('/CreateWorkspace')
   }
   
   return (


### PR DESCRIPTION
## Summary
- Fixed issue where logged-in users visiting the root domain were prompted to login again
- Added authentication check to the home page that redirects authenticated users to their workspace
- Follows the same redirect flow as the middleware (CreateUser → CreateWorkspace → workspace)

## Test plan
- [x] Visit https://www.daygent.ai/ when not logged in - should see login page
- [x] Visit https://www.daygent.ai/ when logged in - should redirect to workspace
- [x] Visit https://www.daygent.ai/ when logged in but no profile - should redirect to /CreateUser
- [x] Visit https://www.daygent.ai/ when logged in but no workspace - should redirect to /CreateWorkspace

🤖 Generated with [Claude Code](https://claude.ai/code)