### PR TITLE
feat: update Daygent wordmark to use Orbitron font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Orbitron } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { KeyboardProvider } from "@/lib/keyboard";
@@ -13,6 +13,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const orbitron = Orbitron({
+  variable: "--font-orbitron",
+  subsets: ["latin"],
+  weight: ["700"],
 });
 
 export const metadata: Metadata = {
@@ -34,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} ${orbitron.variable} antialiased overflow-x-hidden`}
       >
         <ProfileProvider>
           <KeyboardProvider>

--- a/components/layout/header-wrapper.tsx
+++ b/components/layout/header-wrapper.tsx
@@ -12,7 +12,7 @@ export function HeaderWrapper() {
         <div className="w-full px-4 md:px-6 lg:px-8">
           <div className="flex items-center h-11">
             <div className="flex items-center flex-1">
-              <div className="text-xl font-bold text-foreground">Daygent</div>
+              <div className="text-xl font-bold text-foreground font-[family-name:var(--font-orbitron)] tracking-[0.15em]">Daygent</div>
             </div>
             <div className="flex items-center flex-1 justify-end">
               <div className="w-11 h-11 md:w-10 md:h-10 rounded-full bg-secondary animate-pulse" />

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -61,7 +61,7 @@ export function Header({ initialProfile, onMenuToggle, isMobileMenuOpen }: Heade
                 )}
               </button>
             )}
-            <Link href="/daygent" className="text-xl font-bold text-foreground">
+            <Link href="/daygent" className="text-xl font-bold text-foreground font-[family-name:var(--font-orbitron)] tracking-[0.15em]">
               Daygent
             </Link>
           </div>

--- a/test/utils/mock-factory.ts
+++ b/test/utils/mock-factory.ts
@@ -20,40 +20,46 @@ export const createMockSupabaseClient = (overrides: any = {}) => {
     ...overrides.auth,
   }
 
+  // Store table queries to ensure consistency
+  const tableQueries: Record<string, any> = {}
+
   const mockFrom = vi.fn((table: string) => {
-    const mockQuery = {
-      select: vi.fn().mockReturnThis(),
-      insert: vi.fn().mockReturnThis(),
-      update: vi.fn().mockReturnThis(),
-      delete: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      neq: vi.fn().mockReturnThis(),
-      gt: vi.fn().mockReturnThis(),
-      gte: vi.fn().mockReturnThis(),
-      lt: vi.fn().mockReturnThis(),
-      lte: vi.fn().mockReturnThis(),
-      like: vi.fn().mockReturnThis(),
-      ilike: vi.fn().mockReturnThis(),
-      is: vi.fn().mockReturnThis(),
-      in: vi.fn().mockReturnThis(),
-      contains: vi.fn().mockReturnThis(),
-      containedBy: vi.fn().mockReturnThis(),
-      range: vi.fn().mockReturnThis(),
-      overlaps: vi.fn().mockReturnThis(),
-      match: vi.fn().mockReturnThis(),
-      not: vi.fn().mockReturnThis(),
-      or: vi.fn().mockReturnThis(),
-      filter: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: null, error: null }),
-      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-      limit: vi.fn().mockReturnThis(),
-      order: vi.fn().mockReturnThis(),
-      
-      // Override with table-specific mocks
-      ...(overrides[table] || {}),
+    if (!tableQueries[table]) {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockReturnThis(),
+        gt: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lt: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        like: vi.fn().mockReturnThis(),
+        ilike: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        contains: vi.fn().mockReturnThis(),
+        containedBy: vi.fn().mockReturnThis(),
+        range: vi.fn().mockReturnThis(),
+        overlaps: vi.fn().mockReturnThis(),
+        match: vi.fn().mockReturnThis(),
+        not: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        filter: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        limit: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        
+        // Override with table-specific mocks
+        ...(overrides[table] || {}),
+      }
+      tableQueries[table] = mockQuery
     }
     
-    return mockQuery
+    return tableQueries[table]
   })
 
   return {


### PR DESCRIPTION
## Summary
- Updated the Daygent wordmark in the app header to use Orbitron font at 700 weight with 0.15em letter-spacing
- Added Orbitron font import to the root layout
- Fixed failing tests by updating the mock factory to properly handle Supabase client mocking

## Changes Made
1. Added Orbitron font configuration in `app/layout.tsx`
2. Updated header components to apply the new font styling:
   - `components/layout/header.tsx` - Main header component
   - `components/layout/header-wrapper.tsx` - Loading state header
3. Fixed test infrastructure in `test/utils/mock-factory.ts` to ensure consistent mocking

## Test plan
- [x] All tests pass (`npm test`)
- [x] TypeScript type checking passes (`npm run type-check`)
- [x] ESLint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Visual verification of the Daygent wordmark with Orbitron font
- [ ] Verify font loads correctly across different browsers

🤖 Generated with [Claude Code](https://claude.ai/code)