### PR TITLE
Add role="dialog" attribute to DialogContent for accessibility

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -37,6 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      role="dialog"
       data-keyboard-ignore="true"
       className={cn(
         "fixed inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] z-50 grid w-full sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] gap-4 border-0 sm:border bg-background p-4 md:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg h-full sm:h-auto",


### PR DESCRIPTION
## Summary
- Adds `role="dialog"` attribute to the `DialogContent` component in the UI dialog
- Improves accessibility by explicitly defining the dialog role for screen readers

## Changes

### UI Components
- **DialogContent**: Added `role="dialog"` attribute to the `DialogPrimitive.Content` element to enhance semantic meaning and accessibility compliance

## Test plan
- [x] Verify that the dialog renders correctly with the new attribute
- [x] Test accessibility tools to confirm the dialog role is recognized
- [x] Ensure no regressions in dialog behavior or styling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ff5a0c41-bced-4c12-9cea-d935603b7970