### PR TITLE
Hide Recipes Navigation and Shortcut

### DIFF
--- a/components/command-palette/command-palette.tsx
+++ b/components/command-palette/command-palette.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Search, FileText, /* Inbox, */ Plus, Clock, LayoutGrid, Keyboard, Sparkles, CheckCircle, Circle, Loader2, ListTodo, Kanban, Palette, Package, BookOpen } from "lucide-react"
+import { Search, FileText, /* Inbox, */ Plus, Clock, LayoutGrid, Keyboard, Sparkles, CheckCircle, Circle, Loader2, ListTodo, Kanban, Palette, Package /* BookOpen */ } from "lucide-react"
 import { 
   emitIssueStatusUpdate, 
   emitCreateIssueRequest,
@@ -362,6 +362,7 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
       group: "Quick Access"
     })
 
+    /* Go to Recipes command - HIDDEN
     baseCommands.push({
       id: "go-recipes",
       title: "Go to Recipes",
@@ -373,7 +374,7 @@ export function CommandPalette({ workspaceSlug, workspaceId, onCreateIssue, onTo
       },
       keywords: ["navigate", "recipes", "cookbook", "guides", "templates"],
       group: "Quick Access"
-    })
+    }) */
 
     /* Go to Inbox command - hidden for now but preserved for future use
     baseCommands.push({

--- a/components/layout/workspace-layout.tsx
+++ b/components/layout/workspace-layout.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Plus, ChevronLeft, ChevronRight, HelpCircle, Settings, Terminal, BookOpen, Search, ListTodo, Kanban, Palette, Package } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, HelpCircle, Settings, Terminal, /* BookOpen, */ Search, ListTodo, Kanban, Palette, Package } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { UserWorkspace } from '@/lib/supabase/workspaces'
 import { subscribeToCreateIssueRequests, emitToggleSearch } from '@/lib/events/issue-events'
@@ -55,6 +55,7 @@ export function WorkspaceLayout({
   onNavigateToIssues,
   // @ts-expect-error - Currently hidden but preserved for future use
   onNavigateToInbox,
+  // @ts-expect-error - Currently hidden but preserved for future use
   onNavigateToCookbook,
   onNavigateToSprintBoard,
   onNavigateToDesign,
@@ -301,8 +302,8 @@ export function WorkspaceLayout({
           </Link>
         )}
         
-        {/* Recipes (formerly Cookbook) */}
-        {onNavigateToCookbook ? (
+        {/* Recipes (formerly Cookbook) - HIDDEN */}
+        {/* {onNavigateToCookbook ? (
           <button
             data-sidebar-item
             onClick={onNavigateToCookbook}
@@ -328,7 +329,7 @@ export function WorkspaceLayout({
             <BookOpen className="w-5 h-5" />
             <span>Recipes</span>
           </Link>
-        )}
+        )} */}
         
         {/* Command Palette */}
         <button
@@ -549,8 +550,8 @@ export function WorkspaceLayout({
                   <Package className="w-5 h-5 text-muted-foreground" />
                 </Link>
               )}
-              {/* Recipes */}
-              {onNavigateToCookbook ? (
+              {/* Recipes - HIDDEN */}
+              {/* {onNavigateToCookbook ? (
                 <button
                   onClick={onNavigateToCookbook}
                   className={`p-2 rounded mb-2 transition-colors ${
@@ -574,7 +575,7 @@ export function WorkspaceLayout({
                 >
                   <BookOpen className="w-5 h-5 text-muted-foreground" />
                 </Link>
-              )}
+              )} */}
               <button
                 onClick={() => openWithMode('normal')}
                 className="p-2 rounded mb-2 hover:bg-accent transition-colors"

--- a/hooks/use-global-shortcuts.tsx
+++ b/hooks/use-global-shortcuts.tsx
@@ -221,13 +221,14 @@ export function useGlobalShortcuts({
         },
         description: 'Go to product',
       },
+      /* Go to recipes shortcut - HIDDEN
       'gr': {
         handler: () => {
           router.push(`/${workspaceSlug}/cookbook`)
           return true
         },
         description: 'Go to recipes',
-      },
+      }, */
       /* Go to inbox shortcut - hidden for now but preserved for future use
       'gn': {
         handler: () => {


### PR DESCRIPTION
## Summary
- Temporarily hides the "Recipes" navigation elements and related shortcut in the UI
- Removes the "Go to Recipes" command from the command palette
- Comments out the Recipes sidebar button and related UI components
- Disables the global shortcut for navigating to Recipes

## Changes

### Command Palette
- Commented out the "Go to Recipes" command to hide it from quick access

### Workspace Layout
- Commented out the Recipes sidebar button and related navigation links
- Removed the BookOpen icon import where it was only used for Recipes

### Global Shortcuts
- Disabled the global shortcut `gr` for navigating to Recipes by commenting it out

## Test plan
- Verify that the Recipes button is no longer visible in the sidebar
- Confirm that the "Go to Recipes" command does not appear in the command palette
- Check that the `gr` shortcut no longer triggers navigation to Recipes
- Ensure no errors occur due to the commented out code

This change preserves the Recipes feature code for future reactivation but hides it from users for now.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ed7eb27e-a084-40e6-9ed0-5d09c5267ddb