### PR TITLE
Hide search hint label on mobile in workspace content

### DIFF
--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -464,7 +464,7 @@ export const WorkspaceContent = forwardRef<WorkspaceContentRef, WorkspaceContent
               
               {/* Search hint when search is hidden */}
               {!isSearchVisible && !debouncedSearchQuery && (
-                <div className="text-sm text-muted-foreground">
+                <div className="hidden sm:block text-sm text-muted-foreground">
                   Press <kbd className="px-1.5 py-0.5 text-xs bg-muted border border-border rounded">/</kbd> to search
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Hides the search hint label on mobile devices in the workspace content component
- Ensures the hint is only visible on screen sizes medium and above (sm breakpoint)

## Changes

### UI Components
- Updated `WorkspaceContent` component:
  - Wrapped the search hint `<div>` with `hidden sm:block` classes to hide it on small screens

## Test plan
- [x] Verify the search hint label is hidden on mobile screen sizes
- [x] Confirm the search hint label is visible on tablet and desktop screen sizes
- [x] Check that the keyboard shortcut hint (`/`) remains correctly styled and functional

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/689830de-0de4-48a1-a981-66a3d127b0d4