### PR TITLE
Fix label typo from 'Severity' to 'Priority' in sort options

### DIFF
--- a/components/workspace/workspace-content.tsx
+++ b/components/workspace/workspace-content.tsx
@@ -121,8 +121,8 @@ const priorityOptions = [
 const sortOptions = [
   { value: 'newest', label: 'Newest' },
   { value: 'oldest', label: 'Oldest' },
-  { value: 'priority_high', label: 'Severity (High)' },
-  { value: 'priority_low', label: 'Severity (Low)' },
+  { value: 'priority_high', label: 'Priority (High)' },
+  { value: 'priority_low', label: 'Priority (Low)' },
   { value: 'type', label: 'Type' },
   { value: 'tag', label: 'Tag' },
 ]


### PR DESCRIPTION
## Summary
- Corrects the label for priority-based sorting options in the workspace content component
- Changes "Severity (High)" and "Severity (Low)" labels to "Priority (High)" and "Priority (Low)" respectively

## Changes

### UI Components
- Updated `sortOptions` array in `workspace-content.tsx`:
  - Changed label for `priority_high` from "Severity (High)" to "Priority (High)"
  - Changed label for `priority_low` from "Severity (Low)" to "Priority (Low)"

## Test plan
- [x] Verify that the sort dropdown displays "Priority (High)" and "Priority (Low)" instead of "Severity"
- [x] Confirm sorting functionality remains unchanged and works as expected with the updated labels

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/35847aeb-8416-4d04-af36-e39236ecde88